### PR TITLE
Supporting long-read datasets and making them compatible with short-read datasets.

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -1,0 +1,5 @@
+testgz:
+	python vcf2queryTable.py -i ../test2/POG_COLO829_LFT.vcf.gz -o test.query.txt
+
+testtxt:
+	python vcf2queryTable.py -i ../test2/POG_COLO829_LFT.vcf -o test.query.txt

--- a/scripts/vcf2queryTable.py
+++ b/scripts/vcf2queryTable.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import gzip
+import sys
+from collections import Counter, OrderedDict
+
+parser = argparse.ArgumentParser(prog="Convert VCF to query table for STIX")
+parser.add_argument("-i", "--input", help="Input VCF file", required=True)
+parser.add_argument("-o", "--output", help="Output file", required=True)
+parser.add_argument("-c", "--comment", help="Comments appended in ID",default=None,type=str)
+parser.add_argument(
+    "--pad", help="Padding bases for the left and right breakpoint for all SVTYPE except INS", default=10, type=int)
+parser.add_argument(
+    "--allow_no_pass", help="Allow variants with out PASS flag", action='store_true')
+parser.add_argument("--allow_imprecise",
+                    help="Allow IMPRECISE", action='store_true')
+parser.add_argument("--allow_emptyGT",
+                    help="Allow GTs such as ./.", action='store_true')
+parser.add_argument("--allow_all",
+                    help="Allow all variants", action='store_true')
+# parser.add_argument("--allow_allSVTYPE", help="Allow all SVTYPEs such as complex SVs which are not in <DEL>,<INS>,<DUP>,<INV>,<BND>",action='store_true')
+parser.add_argument(
+    "--id", help="Which info fields should be used in the ID column, use ',' link multiple", default="")
+
+args = parser.parse_args()
+
+assert os.path.exists(args.input), f"Not found input file:{args.input}"
+record_idx = 0
+input_records_count = 0
+success_records_count = []
+inf = None
+if os.path.splitext(args.input)[1] == ".gz":
+    inf = gzip.open(args.input, 'rt')
+else:
+    inf = open(args.input)
+
+
+with open(args.output, 'w') as outf:
+    for line in inf:
+        record_idx += 1
+        xline = line.strip()
+        if xline.startswith("#"):
+            continue
+        xline_sp = xline.split("\t")
+        input_records_count +=1
+        if len(xline_sp) < 10:
+            print(
+                "Ignore line at {record_idx} with less than 10 columns",
+                file=sys.stderr)
+            continue
+
+        chro = xline_sp[0]
+        pos = xline_sp[1]
+        ID = xline_sp[2]
+        refseq = xline_sp[3]
+        altseq = xline_sp[4]
+        flag = xline_sp[6]
+        info_str = xline_sp[7]
+        info_list_raw = info_str.split(";")
+        info_dict = {}
+        for term in info_list_raw:
+            if "=" in term:
+                k, v = term.split("=")
+                info_dict[k] = v
+            else:
+                info_dict[term] = True
+        format_str = xline_sp[8]
+        GTidx = 0
+        for x in format_str.split(":"):
+            if x.strip().upper() != "GT":
+                GTidx += 1
+                continue
+            else:
+                break
+        sample_str = xline_sp[9]
+        sample_list = sample_str.split(":")
+        GT = sample_list[GTidx]
+
+        SVTYPE = info_dict.get("SVTYPE", None)
+        if SVTYPE is None:
+            print(f"Ignore record with missing SVTYPE at line {record_idx}",
+                  file=sys.stderr)
+
+        outline = OrderedDict()
+        outline['lchr'] = chro
+        outline['lstart'] = int(pos) - args.pad
+        outline['lend'] = int(pos) + args.pad
+        outline['rchr'] = None
+        outline['rstart'] = None
+        outline['rend'] = None
+        outline['svlen'] = None
+        outline['svtype'] = SVTYPE
+
+        id_want = [x for x in args.id.strip().split(",") if x.strip() != ""]
+        id_out_str = "|".join(
+            [f"{k}={info_dict.get(k)}" for k in id_want if info_dict.get(k, "None") is not None])
+        outline['ID'] = f"GT={GT}|ID={ID}"
+        if len(id_want) > 0:
+            outline['ID'] += "|"+ id_out_str
+        if args.comment is not None:
+            outline['ID'] += "|"+ args.comment
+
+        # for END filed, only SVs which are not BND has this info
+        if SVTYPE == "BND":
+            clean_second_chrpos = altseq.strip().strip(
+                "N").replace("]", "").replace("[", "")
+            second_chr = clean_second_chrpos.split(':')[0]
+            second_pos = int(clean_second_chrpos.split(':')[1])
+            outline['rchr'] = second_chr
+            outline['rstart'] = second_pos - args.pad
+            outline['rend'] = second_pos + args.pad
+            outline['svlen'] = 0
+            pass
+        elif SVTYPE in ['DEL', 'INV', "DUP"]:
+            END = info_dict.get("END", None)
+            SVLEN = info_dict.get("SVLEN", None)
+            if END is not None:
+                outline['rchr'] = chro
+                outline['rstart'] = int(END) - args.pad
+                outline['rend'] = int(END) + args.pad
+                if SVLEN is not None:
+                    outline['svlen'] = abs(int(SVLEN))
+                else:
+                    outline['svlen'] = abs(int(pos) - int(END))
+            else:
+                if SVLEN is not None:
+                    outline['rchr'] = chro
+                    outline['rstart'] = int(pos) + abs(int(SVLEN)) - args.pad
+                    outline['rend'] =  int(pos) + abs(int(SVLEN)) + args.pad
+                    outline['svlen'] = abs(int(SVLEN))
+                else:
+                    print(f"Ignore record without END and SVLEN at same time at line {record_idx}",
+                          file=sys.stderr)
+
+            pass
+        elif SVTYPE == "INS":
+            SVLEN = info_dict.get("SVLEN", None)
+            if SVLEN is not None:
+                outline['lchr'] = chro
+                outline['lstart'] = int(pos) - args.pad * 2
+                outline['lend'] = int(pos)
+                outline['rchr'] = chro
+                outline['rstart'] = int(pos)
+                outline['rend'] = int(pos) + abs(int(SVLEN))
+                outline['svlen'] = abs(int(SVLEN))
+            else:
+                outline['lchr'] = chro
+                outline['lstart'] = int(pos) - args.pad * 2
+                outline['lend'] = int(pos)
+                outline['rchr'] = chro
+                outline['rstart'] = int(pos)
+                outline['rend'] = int(pos)
+                outline['svlen'] = 0
+                print(f"Processed insertion without SVLEN at line {record_idx}",
+                      file=sys.stderr)
+
+            pass
+        # elif args.allow_allSVTYPE:
+
+        #     pass
+        else:
+            print(f"Ignore record with complex SVTYPE and 'allow_allSVTYPE' set as False at line {record_idx}",
+                  file=sys.stderr)
+            continue
+        
+        if args.allow_all != True:
+
+            if args.allow_no_pass != True:
+                if flag != "PASS":
+                    print(f"Ignore record with non PASS at line {record_idx}",
+                        file=sys.stderr)
+                    continue
+
+            if args.allow_emptyGT != True:
+                if GT not in ['0/0', '1/1', '0/1', '1/0']:
+                    print(f"Ignore record with wrong GT:{GT} at line {record_idx}",
+                        file=sys.stderr)
+                    continue
+
+            if args.allow_imprecise != True:
+                if info_dict.get("IMPRECISE", None) is not None:
+                    print(f"Ignore record IMPRECISE tag at line {record_idx}",
+                        file=sys.stderr)
+                    continue
+
+        #stats
+            
+        success_records_count.append(SVTYPE)
+
+        # output
+        outline_str = None
+        if outline['svtype'] in ['DEL', 'INV', "DUP"]:
+            if outline['lstart'] < outline['rstart']:
+                outf.write(
+                    f"{outline['lchr']}:{outline['lstart']}-{outline['lend']}\t{outline['rchr']}:{outline['rstart']}-{outline['rend']}\t{outline['svlen']}\t{outline['svtype']}\t{outline['ID']}\n")
+
+            else:
+                outf.write(
+                    f"{outline['rchr']}:{outline['rstart']}-{outline['rend']}\t{outline['lchr']}:{outline['lstart']}-{outline['lend']}\t{outline['svlen']}\t{outline['svtype']}\t{outline['ID']}\n")
+        else:
+            outf.write(
+                f"{outline['lchr']}:{outline['lstart']}-{outline['lend']}\t{outline['rchr']}:{outline['rstart']}-{outline['rend']}\t{outline['svlen']}\t{outline['svtype']}\t{outline['ID']}\n")
+
+
+success_records_count_category = Counter(success_records_count)
+print(f"All:{input_records_count},After filteration:{sum(list(success_records_count_category.values()))},By SVTYPE:{success_records_count_category}")

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ BIN=../bin
 OBJ=../obj
 GIGGLE_ROOT=../../giggle
 HTS_ROOT=$(GIGGLE_ROOT)/lib/htslib
-CFLAGS=-O2 -D_FILE_OFFSET_BITS=64 -Werror -Wuninitialized
+CFLAGS=-O2 -D_FILE_OFFSET_BITS=64 -Werror -Wuninitialized 
 #CFLAGS=-g -D_FILE_OFFSET_BITS=64 -Werror -Wuninitialized
 INCLUDES=-I$(HTS_ROOT) -I$(GIGGLE_ROOT) -I$(SQLITE_ROOT)
 LIBS=-ldl -lz -lm -pthread -lcurl

--- a/src/ped.c
+++ b/src/ped.c
@@ -550,7 +550,9 @@ uint32_t ped_create_db(char *ped_file_name,
                 struct uint32_t_str_pair tmp_pair;
                 tmp_pair.str = word;
 
-                struct uint32_t_str_pair *giggle_file_i =
+                //struct uint32_t_str_pair *   =
+
+                struct uint32_t_str_pair * giggle_file_i  =
                     bsearch(&tmp_pair,
                             giggle_names_order, 
                             num_files,

--- a/src/ped.c
+++ b/src/ped.c
@@ -354,7 +354,7 @@ uint32_t ped_create_db(char *ped_file_name,
         giggle_names_order[i].str = strdup(basename(names[i]));
     }
 
-    // ### 快排，最后一个是compare的方法，直接返回大小
+    // ### quick sort, the last parameter is the sort function.
     qsort(giggle_names_order, 
           num_files,
           sizeof(struct uint32_t_str_pair),

--- a/src/ped.c
+++ b/src/ped.c
@@ -353,6 +353,8 @@ uint32_t ped_create_db(char *ped_file_name,
         // strip out the path info from names
         giggle_names_order[i].str = strdup(basename(names[i]));
     }
+
+    // ### 快排，最后一个是compare的方法，直接返回大小
     qsort(giggle_names_order, 
           num_files,
           sizeof(struct uint32_t_str_pair),

--- a/src/search.c
+++ b/src/search.c
@@ -1240,7 +1240,7 @@ uint32_t stix_get_summary(struct uint_pair *sample_alt_depths,
         sum = sample_alt_depths[idx].first + sample_alt_depths[idx].second; 
         if (sum == 0)
             *zero_count = *zero_count + 1;
-        else if (sum == 1) /* What happens if there are more than 1 split reads evidence? */
+        else if (sum >= 1) /* What happens if there are more than 1 split reads evidence? */
             *one_count = *one_count + 1;
         else
         {

--- a/src/search.c
+++ b/src/search.c
@@ -7,7 +7,7 @@
 #include <htslib/hfile.h>
 #include <htslib/vcf.h>
 
-//from giggle
+// from giggle
 #include <src/giggle_index.h>
 #include <src/ll.h>
 #include <src/file_read.h>
@@ -19,10 +19,9 @@
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 
 #ifndef ZXCDEBUG
-    #define ZXCDEBUG
+#define ZXCDEBUG
 
 #endif
-
 
 uint32_t safe_sub(uint32_t a, uint32_t b)
 {
@@ -58,15 +57,17 @@ uint32_t stix_parse_result(char *result,
                            struct stix_breakpoint **right,
                            uint32_t *evidence_type)
 {
-    if (*left == NULL) {
+    if (*left == NULL)
+    {
         *left = (struct stix_breakpoint *)
-                malloc(sizeof(struct stix_breakpoint));
+            malloc(sizeof(struct stix_breakpoint));
         (*left)->chrm = NULL;
     }
 
-    if (*right == NULL) {
+    if (*right == NULL)
+    {
         *right = (struct stix_breakpoint *)
-                malloc(sizeof(struct stix_breakpoint));
+            malloc(sizeof(struct stix_breakpoint));
         (*right)->chrm = NULL;
     }
 
@@ -96,52 +97,64 @@ uint32_t stix_parse_result(char *result,
 
 //{{{uint32_t stix_check_sv(struct stix_breakpoint *q_left_bp,
 uint32_t stix_check_sv(struct stix_breakpoint *q_left_bp,
-                        struct stix_breakpoint *q_right_bp,
-                        struct stix_breakpoint *in_left_bp,
-                        struct stix_breakpoint *in_right_bp,
-                        uint32_t evidence_type,
-                        uint32_t slop,
-                        enum stix_sv_type sv_type)
+                       struct stix_breakpoint *q_right_bp,
+                       struct stix_breakpoint *in_left_bp,
+                       struct stix_breakpoint *in_right_bp,
+                       uint32_t evidence_type,
+                       uint32_t slop,
+                       uint32_t ins_padding,
+                       enum stix_sv_type sv_type)
 {
-   switch (sv_type) {
-        case DEL: 
-            return stix_check_del(q_left_bp,
-                                  q_right_bp,
-                                  in_left_bp,
-                                  in_right_bp,
-                                  evidence_type,
-                                  slop);
-            break;
-        case DUP: 
-            return stix_check_dup(q_left_bp,
-                                  q_right_bp,
-                                  in_left_bp,
-                                  in_right_bp,
-                                  evidence_type,
-                                  slop);
-            break;
-        case INV:
-            return stix_check_inv(q_left_bp,
-                                  q_right_bp,
-                                  in_left_bp,
-                                  in_right_bp,
-                                  evidence_type,
-                                  slop);
-            break;
-        case INS:
-            errx(1,"INS not yet supported");
-            break;
-        case BND:
-            return stix_check_bnd(q_left_bp,
-                                  q_right_bp,
-                                  in_left_bp,
-                                  in_right_bp,
-                                  evidence_type,
-                                  slop);
-            break;
-        default:
-            errx(1,"Unknown SV type");
-   } 
+    // printf("%d",sv_type);
+    switch (sv_type)
+    {
+    case DEL:
+        return stix_check_del(q_left_bp,
+                              q_right_bp,
+                              in_left_bp,
+                              in_right_bp,
+                              evidence_type,
+                              slop);
+        break;
+    case DUP:
+        return stix_check_dup(q_left_bp,
+                              q_right_bp,
+                              in_left_bp,
+                              in_right_bp,
+                              evidence_type,
+                              slop);
+        break;
+    case INV:
+        return stix_check_inv(q_left_bp,
+                              q_right_bp,
+                              in_left_bp,
+                              in_right_bp,
+                              evidence_type,
+                              slop);
+        break;
+    case INS:
+        // errx(1,"INS not yet supported");
+        // simply treat a inserson as 1bp deletion.
+        // printf("ins...");
+        return stix_check_ins(q_left_bp,
+                              q_right_bp,
+                              in_left_bp,
+                              in_right_bp,
+                              evidence_type,
+                              slop,
+                              ins_padding);
+        break;
+    case BND:
+        return stix_check_bnd(q_left_bp,
+                              q_right_bp,
+                              in_left_bp,
+                              in_right_bp,
+                              evidence_type,
+                              slop);
+        break;
+    default:
+        errx(1, "Unknown SV type");
+    }
 }
 //}}}
 
@@ -158,30 +171,30 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
      *        v     v
      *   q_l| |   | |q_r
      * ------^ABCDEFG$-----
-     *     +.......+       
+     *     +.......+
      *       +....+
      *        -........-
      *          -....-
      *     +========-
      *        -========+
      *
-     *     +..-   +..- 
-     *       +..-   +..-      
+     *     +..-   +..-
+     *       +..-   +..-
      *     +==+     +==+
      * ------^GFEDCBA$-----
      */
 
-
-
     // Check strand config ++ / -- for paired-end and +- or -+ for split-read
-    if (evidence_type == 0) { // paired-end
+    if (evidence_type == 0)
+    { // paired-end
         if (in_left_bp->strand != in_right_bp->strand)
             return 0;
-    } else { //split read
+    }
+    else
+    { // split read
         if (in_left_bp->strand == in_right_bp->strand)
             return 0;
     }
-
 
     // Ignore "chr" prefix
     char *q_chrm_test = q_right_bp->chrm;
@@ -191,17 +204,15 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
         q_chrm_test += 3;
 
     if (strncmp("chr", in_chrm_test, 3) == 0)
-        in_chrm_test += 3; 
+        in_chrm_test += 3;
 
     // Make sure its intra-chhromosomal
     if (strcmp(q_chrm_test, in_chrm_test) != 0)
         return 0;
 
-
-
     // Make sure its intra-chhromosomal
-    //if (strcmp(q_right_bp->chrm, in_right_bp->chrm) != 0)
-        //return 0;
+    // if (strcmp(q_right_bp->chrm, in_right_bp->chrm) != 0)
+    // return 0;
 
     /*
      *           q_l           q_r
@@ -221,12 +232,12 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
     in_right_bp->end >= q_right_bp->start - slop,
     in_right_bp->start < q_right_bp->end);
     */
- 
-    if ( (in_left_bp->strand == 1) && (in_right_bp->strand == 1) &&//strand
-         (in_left_bp->end >= safe_sub(q_left_bp->start,slop)) && // left side
-         (in_left_bp->start < q_left_bp->end ) &&
-         (in_right_bp->end >= safe_sub(q_right_bp->start,slop))  && // right 
-         (in_right_bp->start < q_right_bp->end ) )
+
+    if ((in_left_bp->strand == 1) && (in_right_bp->strand == 1) && // strand
+        (in_left_bp->end >= safe_sub(q_left_bp->start, slop)) &&   // left side
+        (in_left_bp->start < q_left_bp->end) &&
+        (in_right_bp->end >= safe_sub(q_right_bp->start, slop)) && // right
+        (in_right_bp->start < q_right_bp->end))
         return 1;
 
     /*
@@ -238,11 +249,11 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
      *       ------------ONMLKJIHGFEDCBA--------------
      *                                +..-
      */
-    if ( (in_left_bp->strand == -1) && (in_right_bp->strand == -1) &&//strand
-         (in_left_bp->end >= q_left_bp->start) && // left side
-         (in_left_bp->start < q_left_bp->end + slop) &&
-         (in_right_bp->end >= q_right_bp->start)  && // right side
-         (in_right_bp->start < q_right_bp->end + slop) )
+    if ((in_left_bp->strand == -1) && (in_right_bp->strand == -1) && // strand
+        (in_left_bp->end >= q_left_bp->start) &&                     // left side
+        (in_left_bp->start < q_left_bp->end + slop) &&
+        (in_right_bp->end >= q_right_bp->start) && // right side
+        (in_right_bp->start < q_right_bp->end + slop))
         return 1;
 
     return 0;
@@ -276,7 +287,7 @@ uint32_t stix_check_bnd(struct stix_breakpoint *q_left_bp,
         q_chrm_test += 3;
 
     if (strncmp("chr", in_chrm_test, 3) == 0)
-        in_chrm_test += 3; 
+        in_chrm_test += 3;
 
     // Make sure its intra-chhromosomal
     if (strcmp(q_chrm_test, in_chrm_test) != 0)
@@ -293,15 +304,15 @@ uint32_t stix_check_bnd(struct stix_breakpoint *q_left_bp,
      *
      *              +..............====-
      *
-     *                 +====- 
+     *                 +====-
      *                    +====-
      *     ----------------|-----------------
      *
      */
 
-    // Make sure the right sides intersect 
-    if ( (in_right_bp->end >= q_right_bp->start) &&       // end after start
-         (in_right_bp->start < q_right_bp->end + slop) )  // start before end
+    // Make sure the right sides intersect
+    if ((in_right_bp->end >= q_right_bp->start) &&     // end after start
+        (in_right_bp->start < q_right_bp->end + slop)) // start before end
         return 1;
     else
         return 0;
@@ -317,16 +328,16 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
                         uint32_t slop)
 {
     // Check strand config +- for paired-end and ++ or -- for split-read
-    if (evidence_type == 0) { // paired-end
+    if (evidence_type == 0)
+    { // paired-end
         if ((in_left_bp->strand != 1) || (in_right_bp->strand != -1))
             return 0;
-    } else { //split read
+    }
+    else
+    { // split read
         if (in_left_bp->strand != in_right_bp->strand)
             return 0;
     }
-
-
-
 
     // Ignore "chr" prefix
     char *q_chrm_test = q_right_bp->chrm;
@@ -336,7 +347,7 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
         q_chrm_test += 3;
 
     if (strncmp("chr", in_chrm_test, 3) == 0)
-        in_chrm_test += 3; 
+        in_chrm_test += 3;
 
     // Make sure its intra-chhromosomal
     if (strcmp(q_chrm_test, in_chrm_test) != 0)
@@ -353,42 +364,104 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
      *
      *              +..............====-
      *
-     *                 +====- 
+     *                 +====-
      *                    +====-
      *     ----------------|-----------------
      *
      */
 
-    // Make sure the right sides intersect 
-    if ( (in_right_bp->end >= q_right_bp->start) &&       // end after start
-         (in_right_bp->start < q_right_bp->end + slop) )  // start before end
-        {
+    // Make sure the right sides intersect
+    if ((in_right_bp->end >= q_right_bp->start) &&     // end after start
+        (in_right_bp->start < q_right_bp->end + slop)) // start before end
+    {
 
         // #ifdef ZXCDEBUG
         //     fprintf(stderr,
         //             "debug: "
-        //             "query_left:%s %u %u\tresult_left:%s %u %u\tquery_right:%s %u %u\tresult_right:%s %u %u\n", 
-        //             q_left_bp->chrm, 
+        //             "query_left:%s %u %u\tresult_left:%s %u %u\tquery_right:%s %u %u\tresult_right:%s %u %u\n",
+        //             q_left_bp->chrm,
         //             q_left_bp->start,
         //             q_left_bp->end,
 
-                    
-        //             in_left_bp->chrm, 
+        //             in_left_bp->chrm,
         //             in_left_bp->start,
         //             in_left_bp->end,
 
-        //             q_right_bp->chrm, 
+        //             q_right_bp->chrm,
         //             q_right_bp->start,
         //             q_right_bp->end,
 
-        //             in_right_bp->chrm, 
+        //             in_right_bp->chrm,
         //             in_right_bp->start,
         //             in_right_bp->end
         //             );
         // #endif
 
         return 1;
-        }
+    }
+    else
+        return 0;
+}
+//}}}
+
+//{{{uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
+uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
+                        struct stix_breakpoint *q_right_bp,
+                        struct stix_breakpoint *in_left_bp,
+                        struct stix_breakpoint *in_right_bp,
+                        uint32_t evidence_type,
+                        uint32_t slop,
+                        uint32_t ins_padding )
+{
+    // Check strand config +- for paired-end and ++ or -- for split-read
+    if (evidence_type == 0)
+    { // paired-end
+        if ((in_left_bp->strand != 1) || (in_right_bp->strand != -1))
+            return 0;
+    }
+    else
+    { // split read
+        if (in_left_bp->strand != in_right_bp->strand)
+            return 0;
+    }
+
+    // printf("checking INS1...\n");
+
+    // Igbnore "chr" prefix
+    char *q_chrm_test = q_right_bp->chrm;
+    char *in_chrm_test = in_right_bp->chrm;
+
+    if (strncmp("chr", q_chrm_test, 3) == 0)
+        q_chrm_test += 3;
+
+    if (strncmp("chr", in_chrm_test, 3) == 0)
+        in_chrm_test += 3;
+
+    // Make sure its intra-chhromosomal
+    if (strcmp(q_chrm_test, in_chrm_test) != 0)
+        return 0;
+
+    // printf("checking INS2...\n");
+    /*
+            reads ---------------|***************|-----------------
+            ref   -----------------------|-------------------------
+                    in_left_bp---------->|<-----------in_right_bp--
+                                         |<- zero bp   # step1
+                          qleftbp-end->|~~~~|<-- q_rightbp-start   # step2
+    */
+    // printf("insertion detected..");
+    // Make sure the interval is a insertion record.
+    if (in_right_bp->start != in_left_bp->end)
+        return 0;
+
+    // printf("checking INS3...\n");
+    printf("---\n%d,%d\n%d,%d\n", q_left_bp->end, in_right_bp->start, q_right_bp->start, in_right_bp->start);
+    // Make sure the insertion located in query region
+    if (((q_left_bp->end - ins_padding) < in_right_bp->start) &&  // end after start
+        ((q_right_bp->start + ins_padding) > in_right_bp->start)) // start before end
+    {
+        return 1;
+    }
     else
         return 0;
 }
@@ -403,10 +476,13 @@ uint32_t stix_check_dup(struct stix_breakpoint *q_left_bp,
                         uint32_t slop)
 {
     // Check strand config -+ for paired-end and ++ or -- for split-read
-    if (evidence_type == 0) { // paired-end
+    if (evidence_type == 0)
+    { // paired-end
         if ((in_left_bp->strand != -1) || (in_right_bp->strand != 1))
             return 0;
-    } else { //split read
+    }
+    else
+    { // split read
         if (in_left_bp->strand != in_right_bp->strand)
             return 0;
     }
@@ -419,7 +495,7 @@ uint32_t stix_check_dup(struct stix_breakpoint *q_left_bp,
         q_chrm_test += 3;
 
     if (strncmp("chr", in_chrm_test, 3) == 0)
-        in_chrm_test += 3; 
+        in_chrm_test += 3;
 
     // Make sure its intra-chhromosomal
     if (strcmp(q_chrm_test, in_chrm_test) != 0)
@@ -436,7 +512,7 @@ uint32_t stix_check_dup(struct stix_breakpoint *q_left_bp,
      *                -.......+===
      *                ===-.......+
      *
-     *                        +====- 
+     *                        +====-
      *                           +====-
      *               +------------+------------+
      *     ----------|            |            |----------
@@ -465,21 +541,20 @@ uint32_t stix_check_dup(struct stix_breakpoint *q_left_bp,
             slop,
             q_right_bp->end);
 
-    fprintf(stderr, 
+    fprintf(stderr,
             "%d %d %d %d\n",
             (in_left_bp->end + slop >= q_left_bp->start),
             (in_left_bp->start < q_left_bp->end),
             (in_right_bp->end >= q_right_bp->start),
             (in_right_bp->start - slop < q_right_bp->end));
     */
- 
 
-    // Make sure the left and right sides intersect 
-    if ( (in_left_bp->end >= q_left_bp->start) &&        // l end after start
-         (in_left_bp->start < q_left_bp->end + slop) &&  // l start before end
-         (in_right_bp->end >= q_right_bp->start - slop) &&        // r end after start
-         (in_right_bp->start < q_right_bp->end ) )   // r start before end
-         //(safe_sub(in_right_bp->start,slop) < q_right_bp->end) )   // r start before end
+    // Make sure the left and right sides intersect
+    if ((in_left_bp->end >= q_left_bp->start) &&          // l end after start
+        (in_left_bp->start < q_left_bp->end + slop) &&    // l start before end
+        (in_right_bp->end >= q_right_bp->start - slop) && // r end after start
+        (in_right_bp->start < q_right_bp->end))           // r start before end
+                                                          //(safe_sub(in_right_bp->start,slop) < q_right_bp->end) )   // r start before end
         return 1;
     else
         return 0;
@@ -493,30 +568,30 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                struct stix_breakpoint *q_left_bp,
                                struct stix_breakpoint *q_right_bp,
                                uint32_t slop,
+                               uint32_t ins_padding,
                                uint32_t *sample_ids,
                                uint32_t num_samples,
                                struct uint_pair **sample_alt_depths)
 {
 
-
     fprintf(stderr,
             "stix_run_giggle_query: "
-            "left:%s %u %u\tright:%s %u %u\n", 
-            q_left_bp->chrm, 
+            "left:%s %u %u\tright:%s %u %u\n",
+            q_left_bp->chrm,
             q_left_bp->start,
             q_left_bp->end,
-            q_right_bp->chrm, 
+            q_right_bp->chrm,
             q_right_bp->start,
             q_right_bp->end);
 
-
-    if (*gi == NULL) {
+    if (*gi == NULL)
+    {
         *gi = giggle_load(giggle_index_dir,
                           block_store_giggle_set_data_handler);
         if (*gi == NULL)
             errx(1,
                  "ERROR stix_run_giggle_query(): "
-                 "Error loading giggle index %s.", 
+                 "Error loading giggle index %s.",
                  giggle_index_dir);
     }
 
@@ -544,10 +619,10 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
      *               |       |
      *               v       v
      *     Ref  -----^ABCDEFG$-----
-     *                -...+ 
+     *                -...+
      *                  -...+
      *        q_start|   |q_end
-     *           
+     *
      *                    +==-
      *                      +==-
      *  Sample  -----^ABCDEFGABCDEFG$-----
@@ -564,9 +639,9 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
      *                  -....-
      *    q_start|   |q_end
      *                q_start|   |q_end
-     *             
-     *             +==-           
-     *               +==-         
+     *
+     *             +==-
+     *               +==-
      *                      +==-
      *                    +==-
      *  Sample  -----^GFEDCAB$-----
@@ -574,14 +649,19 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
      *
      */
 
-    if (sv_type == DEL) {
+    if (sv_type == DEL)
+    {
         if (q_start < slop)
             q_start = 0;
         else
             q_start -= slop;
-    } else if (sv_type == DUP) {
+    }
+    else if (sv_type == DUP)
+    {
         q_end += slop;
-    } else if (sv_type == INV) {
+    }
+    else if (sv_type == INV)
+    {
         if (q_start < slop)
             q_start = 0;
         else
@@ -594,24 +674,26 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                                    q_start,
                                                    q_end,
                                                    NULL);
-    //DEBUG
-    // printf("gqr->num_files:%d\nnum_samples:%d\n",gqr->num_files,num_samples);
+    // DEBUG
+    //  printf("gqr->num_files:%d\nnum_samples:%d\n",gqr->num_files,num_samples);
     uint32_t i, N = gqr->num_files;
-    if ((sample_ids != NULL) & (num_samples > 0)){
+    if ((sample_ids != NULL) & (num_samples > 0))
+    {
         N = num_samples;
         // printf("N was modified...");
     }
 
     if (*sample_alt_depths == NULL)
         *sample_alt_depths =
-                (struct uint_pair *)malloc(N * sizeof(struct uint_pair));
+            (struct uint_pair *)malloc(N * sizeof(struct uint_pair));
 
     memset(*sample_alt_depths, 0, N * sizeof(struct uint_pair));
 
     struct stix_breakpoint *in_left_bp = NULL, *in_right_bp = NULL;
     uint32_t evidence_type, idx;
     // loop over the search results for each sample that we care about
-    for(i = 0; i < N; i++) {
+    for (i = 0; i < N; i++)
+    {
         if (num_samples > 0)
             idx = sample_ids[i];
         else
@@ -620,9 +702,12 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
         char *result;
         struct giggle_query_iter *gqi = giggle_get_query_itr(gqr, idx);
 
-        while (giggle_query_next(gqi, &result) == 0) {
+        while (giggle_query_next(gqi, &result) == 0)
+        {
             // parse the extra string info for the matching line in the source
             // file
+            char results2[10000];
+            strcpy(results2, result);
             uint32_t ret = stix_parse_result(result,
                                              &in_left_bp,
                                              &in_right_bp,
@@ -631,17 +716,14 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
             // #ifdef ZXCDEBUG
             //     fprintf(stderr,
             //             "query result: "
-            //             "left:%s %u %u\tright:%s %u %u\n", 
-            //             in_left_bp->chrm, 
+            //             "left:%s %u %u\tright:%s %u %u\n",
+            //             in_left_bp->chrm,
             //             in_left_bp->start,
             //             in_left_bp->end,
-            //             in_right_bp->chrm, 
+            //             in_right_bp->chrm,
             //             in_right_bp->start,
             //             in_right_bp->end);
             // #endif
-
-
-
 
             uint32_t hit = stix_check_sv(q_left_bp,
                                          q_right_bp,
@@ -649,47 +731,48 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                          in_right_bp,
                                          evidence_type,
                                          slop,
+                                         ins_padding,
                                          sv_type);
-            if (hit == 1) {
+            if (hit == 1)
+            {
                 if (evidence_type == 0)
-                    (*sample_alt_depths)[i].first += 1; //pairend-read
+                    (*sample_alt_depths)[i].first += 1; // pairend-read
                 else
-                    (*sample_alt_depths)[i].second += 1; //split-reads
-                
+                    (*sample_alt_depths)[i].second += 1; // split-reads
 
-                        #ifdef ZXCDEBUG
-                            fprintf(stderr,
-                                    "#debug: "
-                                    "query_left:%s %u %u\tresult_left:%s %u %u\tquery_right:%s %u %u\tresult_right:%s %u %u\t%s\n", 
-                                    q_left_bp->chrm, 
-                                    q_left_bp->start,
-                                    q_left_bp->end,
+#ifdef ZXCDEBUG
+                fprintf(stderr,
+                        "#debug: "
+                        "query_left:%s %u %u\tresult_left:%s %u %u\tquery_right:%s %u %u\tresult_right:%s %u %u\t%s\n",
+                        q_left_bp->chrm,
+                        q_left_bp->start,
+                        q_left_bp->end,
 
-                                    
-                                    in_left_bp->chrm, 
-                                    in_left_bp->start,
-                                    in_left_bp->end,
+                        in_left_bp->chrm,
+                        in_left_bp->start,
+                        in_left_bp->end,
 
-                                    q_right_bp->chrm, 
-                                    q_right_bp->start,
-                                    q_right_bp->end,
+                        q_right_bp->chrm,
+                        q_right_bp->start,
+                        q_right_bp->end,
 
-                                    in_right_bp->chrm, 
-                                    in_right_bp->start,
-                                    in_right_bp->end,
-                                    result
-                                    );
-                        #endif
+                        in_right_bp->chrm,
+                        in_right_bp->start,
+                        in_right_bp->end,
+                        results2);
+#endif
             }
         }
         giggle_iter_destroy(&gqi);
     }
 
-    if (in_left_bp != NULL) {
+    if (in_left_bp != NULL)
+    {
         free(in_left_bp->chrm);
         free(in_left_bp);
     }
-    if (in_right_bp != NULL) {
+    if (in_right_bp != NULL)
+    {
         free(in_right_bp->chrm);
         free(in_right_bp);
     }
@@ -707,13 +790,15 @@ uint32_t stix_get_uniq(uint32_t *full,
 {
     qsort(full, num_full, sizeof(uint32_t), uint32_t_cmp);
 
-    *uniq = (uint32_t *) malloc(num_full*sizeof(uint32_t));
+    *uniq = (uint32_t *)malloc(num_full * sizeof(uint32_t));
 
     uint32_t i, u_i = 0;
 
-    for (i = 0; i < num_full; ++i) {
-        if ( ((i + 1) == num_full) || (full[i] != full[i+1])) {
-            (*uniq)[u_i++] =  full[i];
+    for (i = 0; i < num_full; ++i)
+    {
+        if (((i + 1) == num_full) || (full[i] != full[i + 1]))
+        {
+            (*uniq)[u_i++] = full[i];
         }
     }
 
@@ -726,32 +811,34 @@ uint32_t stix_get_uniq(uint32_t *full,
 //{{{uint32_t stix_get_quartile_counts(uint32_t *full,
 uint32_t stix_get_quartile_counts(uint32_t *full,
                                   uint32_t num_full,
-                                  uint32_t *Q1, 
-                                  uint32_t *Q2, 
-                                  uint32_t *Q3, 
+                                  uint32_t *Q1,
+                                  uint32_t *Q2,
+                                  uint32_t *Q3,
                                   int32_t *counts)
 {
-    memset(counts, 0, 4*sizeof(int32_t));
-
+    memset(counts, 0, 4 * sizeof(int32_t));
 
     uint32_t *uniq;
     uint32_t num_uniq = stix_get_uniq(full, num_full, &uniq);
 
-    if (num_uniq >= 3) {
-        *Q1 = uniq[num_uniq/4];
-        *Q2 = uniq[num_uniq/2];
-        *Q3 = uniq[MIN(num_uniq/2 + 1 + num_uniq/4, num_uniq-1)];
+    if (num_uniq >= 3)
+    {
+        *Q1 = uniq[num_uniq / 4];
+        *Q2 = uniq[num_uniq / 2];
+        *Q3 = uniq[MIN(num_uniq / 2 + 1 + num_uniq / 4, num_uniq - 1)];
 
         counts[0] = stix_bsearch_seq(*Q1, full, num_full, -1, num_full);
 
         counts[1] = stix_bsearch_seq(*Q2, full, num_full, -1, num_full) -
-                counts[0];
+                    counts[0];
 
         counts[2] = stix_bsearch_seq(*Q3, full, num_full, -1, num_full) -
-                counts[1] - counts[0];
+                    counts[1] - counts[0];
 
         counts[3] = num_full - counts[2] - counts[1] - counts[0];
-    } else if (num_uniq == 3) {
+    }
+    else if (num_uniq == 3)
+    {
         *Q1 = uniq[0];
         *Q2 = uniq[1];
         *Q3 = uniq[2];
@@ -759,7 +846,9 @@ uint32_t stix_get_quartile_counts(uint32_t *full,
         counts[1] = 1;
         counts[2] = 2;
         counts[3] = 3;
-    } else if (num_uniq == 2) {
+    }
+    else if (num_uniq == 2)
+    {
         *Q1 = 0;
         *Q2 = uniq[0];
         *Q3 = uniq[1];
@@ -767,7 +856,9 @@ uint32_t stix_get_quartile_counts(uint32_t *full,
         counts[1] = 0;
         counts[2] = 1;
         counts[3] = 1;
-    } else if (num_uniq == 1) {
+    }
+    else if (num_uniq == 1)
+    {
         *Q1 = 0;
         *Q2 = 0;
         *Q3 = uniq[0];
@@ -775,7 +866,9 @@ uint32_t stix_get_quartile_counts(uint32_t *full,
         counts[1] = 0;
         counts[2] = 0;
         counts[3] = 1;
-    } else if (num_uniq == 0) {
+    }
+    else if (num_uniq == 0)
+    {
         *Q1 = 0;
         *Q2 = 0;
         *Q3 = 0;
@@ -797,18 +890,19 @@ int32_t stix_bsearch_seq(uint32_t key,
                          int32_t lo,
                          int32_t hi)
 {
-        int32_t i = 0;
-        uint32_t mid;
-        while ( hi - lo > 1) {
-                ++i;
-                mid = (hi + lo) / 2;
-                if ( D[mid] < key )
-                        lo = mid;
-                else
-                        hi = mid;
-        }
+    int32_t i = 0;
+    uint32_t mid;
+    while (hi - lo > 1)
+    {
+        ++i;
+        mid = (hi + lo) / 2;
+        if (D[mid] < key)
+            lo = mid;
+        else
+            hi = mid;
+    }
 
-        return hi;
+    return hi;
 }
 //}}}
 
@@ -830,11 +924,12 @@ uint32_t stix_get_summary(struct uint_pair *sample_alt_depths,
     *min = INT_MAX;
     *max = 0;
 
-    uint32_t *full = (uint32_t *)calloc(num_samples,sizeof(uint32_t));
+    uint32_t *full = (uint32_t *)calloc(num_samples, sizeof(uint32_t));
     uint32_t full_i = 0;
 
     uint32_t i, sum, idx;
-    for (i = 0; i < num_samples;  ++i) {
+    for (i = 0; i < num_samples; ++i)
+    {
         if (sample_ids != NULL)
             idx = sample_ids[i];
         else
@@ -845,24 +940,24 @@ uint32_t stix_get_summary(struct uint_pair *sample_alt_depths,
             *zero_count = *zero_count + 1;
         else if (sum == 1)
             *one_count = *one_count + 1;
-        else {
+        else
+        {
             full[full_i] = sum;
             full_i += 1;
         }
 
         if (*min > sum)
             *min = sum;
-        
+
         if (*max < sum)
             *max = sum;
     }
 
-
     uint32_t ret = stix_get_quartile_counts(full,
                                             full_i,
-                                            Q1, 
-                                            Q2, 
-                                            Q3, 
+                                            Q1,
+                                            Q2,
+                                            Q3,
                                             counts);
     free(full);
     return 0;
@@ -875,10 +970,11 @@ uint32_t stix_get_sample_depths(struct uint_pair *sample_alt_depths,
                                 uint32_t num_samples,
                                 uint32_t **sample_depths)
 {
-    *sample_depths = (uint32_t *)calloc(num_samples,sizeof(uint32_t));
+    *sample_depths = (uint32_t *)calloc(num_samples, sizeof(uint32_t));
 
     uint32_t i, idx;
-    for (i = 0; i < num_samples;  ++i) {
+    for (i = 0; i < num_samples; ++i)
+    {
         if (sample_ids != NULL)
             idx = sample_ids[i];
         else
@@ -906,10 +1002,9 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
 
     int size = sizeof(int32_t);
 
-    int ci_size = 2*sizeof(int);
-    int *ciend = (int *) calloc(2, sizeof(int));
-    int *cipos = (int *) calloc(2, sizeof(int));
-
+    int ci_size = 2 * sizeof(int);
+    int *ciend = (int *)calloc(2, sizeof(int));
+    int *cipos = (int *)calloc(2, sizeof(int));
 
     ret = bcf_get_info_string(hdr,
                               line,
@@ -917,12 +1012,14 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                               &sv_type_str,
                               &sv_type_len);
 
-    if (ret == -1) {
+    if (ret == -1)
+    {
         fprintf(stderr, "Warning: Skipping variant. No SVTYPE\n");
         return 1;
     }
 
-    if (sv_type_len < 3) {
+    if (sv_type_len < 3)
+    {
         fprintf(stderr, "Warning: Skipping variant. Unknown SVTYPE: %s\n", sv_type_str);
         return 1;
     }
@@ -933,7 +1030,8 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
         *sv_type = DUP;
     else if (strcmp(sv_type_str, "INV") == 0)
         *sv_type = INV;
-    else {
+    else
+    {
         fprintf(stderr, "Warning: Skipping variant: Unknown SVTYPE: %s\n", sv_type_str);
         return 1;
     }
@@ -941,7 +1039,7 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
     const char *chrm = bcf_hdr_id2name(hdr, line->rid);
 
     int end_size = sizeof(int);
-    int *end = (int *) malloc(end_size);
+    int *end = (int *)malloc(end_size);
 
     ret = bcf_get_info_int32(hdr,
                              line,
@@ -949,9 +1047,10 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &end,
                              &end_size);
 
-    if (ret == -1) {
+    if (ret == -1)
+    {
         int sv_len_size = sizeof(int);
-        int *sv_len = (int *) malloc(sv_len_size);
+        int *sv_len = (int *)malloc(sv_len_size);
 
         ret = bcf_get_info_int32(hdr,
                                  line,
@@ -959,7 +1058,8 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                                  &sv_len,
                                  &sv_len_size);
 
-        if (ret == -1) {
+        if (ret == -1)
+        {
             fprintf(stderr, "Warning: Skipping variant. No END and NO SVLEN\n");
             free(end);
             free(sv_len);
@@ -984,7 +1084,8 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &cipos,
                              &ci_size);
 
-    if (ret != -1) {
+    if (ret != -1)
+    {
         left->start += cipos[0];
         left->end += cipos[1];
     }
@@ -1000,7 +1101,8 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              "CIEND",
                              &ciend,
                              &ci_size);
-    if (ret != -1) {
+    if (ret != -1)
+    {
         right->start += ciend[0];
         right->end += ciend[1];
     }

--- a/src/search.c
+++ b/src/search.c
@@ -58,6 +58,12 @@ uint32_t stix_parse_result(char *result,
                            struct stix_breakpoint **right,
                            uint32_t *evidence_type)
 {
+
+    if (V_is_set ==1){
+        fprintf(stderr,"##stix_parse_result--results: %s\n",result);
+        fflush(stderr);
+    }
+
     if (*left == NULL)
     {
         *left = (struct stix_breakpoint *)
@@ -423,8 +429,8 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
             ov = -1.0;
             if (V_is_set)
             {
-                printf("#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
-                fflush(stdout);
+                fprintf(stderr,"#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
+                fflush(stderr);
             }
             // return 0;
         }
@@ -452,8 +458,8 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
             ov = -1.0;
             if (V_is_set)
             {
-                printf("#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
-                fflush(stdout);
+                fprintf(stderr,"#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
+                fflush(stderr);
             }
         }
         else
@@ -475,8 +481,8 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
 
     if (V_is_set)
     {
-        printf("#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
-        fflush(stdout);
+        fprintf(stderr,"#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
+        fflush(stderr);
     }
     if (ov > 0.0)
     {
@@ -576,14 +582,14 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
 
             if (V_is_set)
             {
-                printf("#ins hit:exact match\n");
-                fflush(stdout);
-                printf("#ins debug exact match: \n# in_right_bp->start: %d, q_right_bp->end: %d,\n",
+                fprintf(stderr,"#ins hit:exact match\n");
+                fflush(stderr);
+                fprintf(stderr,"#ins debug exact match: \n# in_right_bp->start: %d, q_right_bp->end: %d,\n",
 
                        in_right_bp->start,
 
                        q_left_bp->end);
-                fflush(stdout);
+                fflush(stderr);
             }
 
             // further compare length. beacuse multiple insertions exists in same insert point.
@@ -648,11 +654,11 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
             {
                 if (V_is_set)
                 {
-                    printf("#ins debug: found distance of quey: %d  and results:%d are more than slop %d \n",
+                    fprintf(stderr,"#ins debug: found distance of quey: %d  and results:%d are more than slop %d \n",
                            q_left_bp->end,
                            in_left_bp->end,
                            slop);
-                    fflush(stdout);
+                    fflush(stderr);
                 }
 
                 return 0;
@@ -671,7 +677,7 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                 }
                 if (V_is_set == 1)
                 {
-                    printf("#ins debug: \n#  in_right_bp->end: %d, in_right_bp->start: %d, results_len: %d\n#  q_right_bp->end: %d, q_right_bp->start: %d, query_len: %d  \n#  pct: %f\n",
+                    fprintf(stderr,"#ins debug: \n#  in_right_bp->end: %d, in_right_bp->start: %d, results_len: %d\n#  q_right_bp->end: %d, q_right_bp->start: %d, query_len: %d  \n#  pct: %f\n",
                            in_right_bp->end,
                            in_right_bp->start,
                            (in_right_bp->end - in_right_bp->start),
@@ -679,7 +685,7 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                            q_right_bp->start,
                            (q_right_bp->end - q_right_bp->start),
                            pct);
-                    fflush(stdout);
+                    fflush(stderr);
                 }
 
                 // if relative error less than a
@@ -689,8 +695,8 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                     if (V_is_set == 1)
                     {
 
-                        printf("#ins hit:OV <0.2\n");
-                        fflush(stdout);
+                        fprintf(stderr,"#ins hit:OV <0.2\n");
+                        fflush(stderr);
                     }
 
                     return 1;
@@ -712,8 +718,8 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
 
                     if (V_is_set == 1)
                     {
-                        printf("#ins hit: no-length hit\n");
-                        fflush(stdout);
+                        fprintf(stderr,"#ins hit: no-length hit\n");
+                        fflush(stderr);
                     }
 
                     return 1;
@@ -1023,6 +1029,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                             in_right_bp->start,
                             in_right_bp->end,
                             results2);
+                    fflush(stderr);
                 }
             }
             else
@@ -1048,6 +1055,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                             in_right_bp->start,
                             in_right_bp->end,
                             results2);
+                    fflush(stderr);
                 }
             }
         }
@@ -1223,10 +1231,16 @@ uint32_t stix_get_summary(struct uint_pair *sample_alt_depths,
         else
             idx = i;
 
-        sum = sample_alt_depths[idx].first + sample_alt_depths[idx].second;
+        /*from xinchang
+        sample_alt_depths counts the number of evidence == 0 and number of evidence ==1 which is in the seventh column of excord output
+        evidence == 0 ==> paird reads evidence
+        evidence == 1 ==> split reads evidence
+        if you do a sum of sample_alt_depths, you are counting the number of split reads evidence
+        */
+        sum = sample_alt_depths[idx].first + sample_alt_depths[idx].second; 
         if (sum == 0)
             *zero_count = *zero_count + 1;
-        else if (sum == 1)
+        else if (sum == 1) /* What happens if there are more than 1 split reads evidence? */
             *one_count = *one_count + 1;
         else
         {
@@ -1286,7 +1300,7 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
 {
     char *sv_type_str = NULL;
     int sv_type_len = 0;
-    uint32_t ret;
+    uint32_t ret,ret_svlen;
 
     int size = sizeof(int32_t);
 
@@ -1318,6 +1332,8 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
         *sv_type = DUP;
     else if (strcmp(sv_type_str, "INV") == 0)
         *sv_type = INV;
+    else if (strcmp(sv_type_str, "INS") == 0)
+        *sv_type = INS;
     else
     {
         fprintf(stderr, "Warning: Skipping variant: Unknown SVTYPE: %s\n", sv_type_str);
@@ -1335,18 +1351,24 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &end,
                              &end_size);
 
-    if (ret == -1)
+    /* from Xinchang
+        Move SVLEN here, beacuse INS always need this tag
+    */
+    int sv_len_size = sizeof(int);
+    int *sv_len = (int *)malloc(sv_len_size);
+    ret_svlen = bcf_get_info_int32(hdr,
+                            line,
+                            "SVLEN",
+                            &sv_len,
+                            &sv_len_size);
+
+    if (ret == -1) // if END is missing,try to calculate the end from SVLEN tag
     {
-        int sv_len_size = sizeof(int);
-        int *sv_len = (int *)malloc(sv_len_size);
 
-        ret = bcf_get_info_int32(hdr,
-                                 line,
-                                 "SVLEN",
-                                 &sv_len,
-                                 &sv_len_size);
 
-        if (ret == -1)
+
+
+        if (ret_svlen == -1)
         {
             fprintf(stderr, "Warning: Skipping variant. No END and NO SVLEN\n");
             free(end);
@@ -1356,8 +1378,9 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
 
         *end = line->pos + *sv_len;
 
-        free(sv_len);
+        
     }
+
 
     if (left->chrm != NULL)
         free(left->chrm);
@@ -1372,17 +1395,35 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &cipos,
                              &ci_size);
 
-    if (ret != -1)
+    if (ret != -1 )
     {
-        left->start += cipos[0];
-        left->end += cipos[1];
+        /*
+        from xinchang:
+        For insertion, we don't need a confident padding 
+        */
+        if (strcmp(sv_type_str, "INS") != 0){
+            left->start += cipos[0];
+            left->end += cipos[1];
+        }
     }
 
     if (right->chrm != NULL)
         free(right->chrm);
-    right->chrm = strdup(chrm);
-    right->start = *end;
-    right->end = *end;
+
+    /*
+    from xinchang,
+    For insertions, The start of right region is equal to the end of left region.
+    Length information is encoded in the end.
+    */
+    if (strcmp(sv_type_str, "INS") != 0){
+        right->chrm = strdup(chrm);
+        right->start = *end;
+        right->end = *end;
+    }else{
+        right->chrm = strdup(chrm);
+        right->start = line->pos;
+        right->end = line->pos + *sv_len; 
+    }
 
     ret = bcf_get_info_int32(hdr,
                              line,
@@ -1391,14 +1432,16 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &ci_size);
     if (ret != -1)
     {
-        right->start += ciend[0];
-        right->end += ciend[1];
+        if (strcmp(sv_type_str, "INS") != 0){
+            right->start += ciend[0];
+            right->end += ciend[1];
+        }
     }
 
     free(end);
     free(ciend);
     free(cipos);
-
+    free(sv_len);
     return 0;
 }
 //}}}

--- a/src/search.c
+++ b/src/search.c
@@ -515,10 +515,23 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                       qleftbp-end->|~pad~|~pad~|<-- q_rightbp-start   # step2
     */
 
-    // Make sure the interval is a insertion record.
-    if (in_right_bp->start != in_left_bp->end)
-        return 0;
+    // Make sure the interval is a insertion record: right_interval.start == left_interval.end
 
+    /*      left
+        |--------------|    right
+                       |---------------|
+    */
+
+    if (in_right_bp->start != in_left_bp->end) {
+        return 0;
+    }
+    else {
+        // After making sure that the record is a insrtion, If the Position of insertion in query and results are exactly same
+        // report it as a hit. 
+        if(q_left_bp->end == in_left_bp->start){
+            return 1;
+        }
+    }
 
 
     float results_len = (float) (in_right_bp->end - in_right_bp->start );

--- a/src/search.c
+++ b/src/search.c
@@ -105,7 +105,7 @@ uint32_t stix_check_sv(struct stix_breakpoint *q_left_bp,
                        uint32_t ins_padding,
                        enum stix_sv_type sv_type)
 {
-    fprintf(stderr,"SVTYPE:%d\n",sv_type);
+    // fprintf(stderr,"SVTYPE:%d\n",sv_type);
     switch (sv_type)
     {
     case DEL:
@@ -186,12 +186,12 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
 
 
    
-    fprintf(stderr, "#INV\t %d %d %d %d %d\n",
-    (in_left_bp->strand  + in_right_bp->strand) == 0,
-    in_left_bp->end >= q_left_bp->start - slop,
-    in_left_bp->start < q_left_bp->end,
-    in_right_bp->end >= q_right_bp->start - slop,
-    in_right_bp->start < q_right_bp->end);
+    // fprintf(stderr, "#INV\t %d %d %d %d %d\n",
+    // (in_left_bp->strand  + in_right_bp->strand) == 0,
+    // in_left_bp->end >= q_left_bp->start - slop,
+    // in_left_bp->start < q_left_bp->end,
+    // in_right_bp->end >= q_right_bp->start - slop,
+    // in_right_bp->start < q_right_bp->end);
 
     // Check strand config ++ / -- for paired-end and +- or -+ for split-read
     if (evidence_type == 0)
@@ -272,7 +272,9 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
         (in_left_bp->end >= q_left_bp->start) &&                     // left side
         (in_left_bp->start < q_left_bp->end + slop) &&
         (in_right_bp->end >= q_right_bp->start) && // right side
-        (in_right_bp->start < q_right_bp->end + slop))
+        (in_right_bp->start < q_right_bp->end + slop)
+        
+        )
         return 1;
 
 
@@ -284,21 +286,43 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
 
 
 
+    if ((in_left_bp->strand == 1) && (in_right_bp->strand == -1) && // strand
+        (in_left_bp->end >= safe_sub(q_left_bp->start, slop)) &&   // left side
+        (in_left_bp->start < q_left_bp->end) &&
+        (in_right_bp->end >= q_right_bp->start) && // right side
+        (in_right_bp->start < q_right_bp->end + slop)
+        
+        )
+        return 1;
 
-    if (( (in_left_bp->strand  + in_right_bp->strand) == 0 ) && // strand plus strand == 0; -1 and 1 ; 1 and -1
-    (in_left_bp->end >= q_left_bp->start) &&                     // left side
-    (in_left_bp->start < q_left_bp->end + slop) &&
-    (in_right_bp->end >= q_right_bp->start) && // right side
-    (in_right_bp->start < q_right_bp->end + slop))
-    return 1;
-
-
-    if (((in_left_bp->strand  + in_right_bp->strand) == 0) && // strand
+    
+    if ((in_left_bp->strand == -1) && (in_right_bp->strand == 1) && // strand
         (in_left_bp->end >= q_left_bp->start) &&                     // left side
         (in_left_bp->start < q_left_bp->end + slop) &&
-        (in_right_bp->end >= q_right_bp->start) && // right side
-        (in_right_bp->start < q_right_bp->end + slop))
+        (in_right_bp->end >= safe_sub(q_right_bp->start, slop)) && // right
+        (in_right_bp->start < q_right_bp->end)
+        
+        )
         return 1;
+
+
+
+
+
+    // if (( (in_left_bp->strand  + in_right_bp->strand) == 0 ) && // strand plus strand == 0; -1 and 1 ; 1 and -1
+    // (in_left_bp->end >= q_left_bp->start) &&                     // left side
+    // (in_left_bp->start < q_left_bp->end + slop) &&
+    // (in_right_bp->end >= q_right_bp->start) && // right side
+    // (in_right_bp->start < q_right_bp->end + slop))
+    // return 1;
+
+
+    // if (((in_left_bp->strand  + in_right_bp->strand) == 0) && // strand
+    //     (in_left_bp->end >= q_left_bp->start) &&                     // left side
+    //     (in_left_bp->start < q_left_bp->end + slop) &&
+    //     (in_right_bp->end >= q_right_bp->start) && // right side
+    //     (in_right_bp->start < q_right_bp->end + slop))
+    //     return 1;
    
 
     return 0;

--- a/src/search.c
+++ b/src/search.c
@@ -334,10 +334,13 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
             return 0;
     }
     else
-    { // split read
+    { // ignore the insertion region which the left-end = right-start (0bp region)
         if (in_left_bp->strand != in_right_bp->strand)
             return 0;
     }
+
+    if (in_left_bp->end == in_right_bp->start)
+    return 0;
 
     // Ignore "chr" prefix
     char *q_chrm_test = q_right_bp->chrm;
@@ -425,7 +428,6 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
             return 0;
     }
 
-    // printf("checking INS1...\n");
 
     // Igbnore "chr" prefix
     char *q_chrm_test = q_right_bp->chrm;
@@ -441,7 +443,7 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
     if (strcmp(q_chrm_test, in_chrm_test) != 0)
         return 0;
 
-    // printf("checking INS2...\n");
+
     /*
             reads ---------------|***************|-----------------
             ref   -----------------------|-------------------------
@@ -449,12 +451,11 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                                          |<- zero bp   # step1
                           qleftbp-end->|~~~~|<-- q_rightbp-start   # step2
     */
-    // printf("insertion detected..");
+
     // Make sure the interval is a insertion record.
     if (in_right_bp->start != in_left_bp->end)
         return 0;
 
-    // printf("checking INS3...\n");
     printf("---\n%d,%d\n%d,%d\n", q_left_bp->end, in_right_bp->start, q_right_bp->start, in_right_bp->start);
     // Make sure the insertion located in query region
     if (((q_left_bp->end - ins_padding) < in_right_bp->start) &&  // end after start

--- a/src/search.c
+++ b/src/search.c
@@ -185,13 +185,6 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
      * ------^GFEDCBA$-----
      */
 
-    // fprintf(stderr, "#INV\t %d %d %d %d %d\n",
-    // (in_left_bp->strand  + in_right_bp->strand) == 0,
-    // in_left_bp->end >= q_left_bp->start - slop,
-    // in_left_bp->start < q_left_bp->end,
-    // in_right_bp->end >= q_right_bp->start - slop,
-    // in_right_bp->start < q_right_bp->end);
-
     // Check strand config ++ / -- for paired-end and +- or -+ for split-read
     if (evidence_type == 0)
     { // paired-end
@@ -233,16 +226,6 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
      */
 
     /*
-    fprintf(stderr, "%d %d %d %d %d %d\n",
-    in_left_bp->strand == 1 ,
-    in_right_bp->strand == 1,
-    in_left_bp->end >= q_left_bp->start - slop,
-    in_left_bp->start < q_left_bp->end,
-    in_right_bp->end >= q_right_bp->start - slop,
-    in_right_bp->start < q_right_bp->end);
-    */
-
-    /*
     This one is only for pair-end reads..
     */
 
@@ -278,7 +261,7 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
     /*
     from xinchang:
     Here I am going to add some code for long-read.
-    In a word, the following code will handel the regions with += and -+ strand
+    In a word, the following code will handle the regions with +- and -+ strand
     */
 
     if ((in_left_bp->strand == 1) && (in_right_bp->strand == -1) && // strand
@@ -298,20 +281,6 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
 
     )
         return 1;
-
-    // if (( (in_left_bp->strand  + in_right_bp->strand) == 0 ) && // strand plus strand == 0; -1 and 1 ; 1 and -1
-    // (in_left_bp->end >= q_left_bp->start) &&                     // left side
-    // (in_left_bp->start < q_left_bp->end + slop) &&
-    // (in_right_bp->end >= q_right_bp->start) && // right side
-    // (in_right_bp->start < q_right_bp->end + slop))
-    // return 1;
-
-    // if (((in_left_bp->strand  + in_right_bp->strand) == 0) && // strand
-    //     (in_left_bp->end >= q_left_bp->start) &&                     // left side
-    //     (in_left_bp->start < q_left_bp->end + slop) &&
-    //     (in_right_bp->end >= q_right_bp->start) && // right side
-    //     (in_right_bp->start < q_right_bp->end + slop))
-    //     return 1;
 
     return 0;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -105,7 +105,7 @@ uint32_t stix_check_sv(struct stix_breakpoint *q_left_bp,
                        uint32_t ins_padding,
                        enum stix_sv_type sv_type)
 {
-    // printf("%d",sv_type);
+    fprintf(stderr,"SVTYPE:%d\n",sv_type);
     switch (sv_type)
     {
     case DEL:
@@ -184,6 +184,15 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
      * ------^GFEDCBA$-----
      */
 
+
+   
+    fprintf(stderr, "#INV\t %d %d %d %d %d\n",
+    (in_left_bp->strand  + in_right_bp->strand) == 0,
+    in_left_bp->end >= q_left_bp->start - slop,
+    in_left_bp->start < q_left_bp->end,
+    in_right_bp->end >= q_right_bp->start - slop,
+    in_right_bp->start < q_right_bp->end);
+
     // Check strand config ++ / -- for paired-end and +- or -+ for split-read
     if (evidence_type == 0)
     { // paired-end
@@ -194,6 +203,7 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
     { // split read
         if (in_left_bp->strand == in_right_bp->strand)
             return 0;
+        // in split reads, only two coordinate with different strand will go down 
     }
 
     // Ignore "chr" prefix
@@ -232,7 +242,12 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
     in_right_bp->end >= q_right_bp->start - slop,
     in_right_bp->start < q_right_bp->end);
     */
-
+    
+    /*
+    This one is only for pair-end reads..
+    */
+    
+    
     if ((in_left_bp->strand == 1) && (in_right_bp->strand == 1) && // strand
         (in_left_bp->end >= safe_sub(q_left_bp->start, slop)) &&   // left side
         (in_left_bp->start < q_left_bp->end) &&
@@ -249,12 +264,42 @@ uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
      *       ------------ONMLKJIHGFEDCBA--------------
      *                                +..-
      */
+
+    /*
+    This one is only for pair-end reads too..
+    */
     if ((in_left_bp->strand == -1) && (in_right_bp->strand == -1) && // strand
         (in_left_bp->end >= q_left_bp->start) &&                     // left side
         (in_left_bp->start < q_left_bp->end + slop) &&
         (in_right_bp->end >= q_right_bp->start) && // right side
         (in_right_bp->start < q_right_bp->end + slop))
         return 1;
+
+
+    /*
+    from xinchang:
+    Here I am going to add some code for long-read.
+    In a word, the following code will handel the regions with += and -+ strand
+    */
+
+
+
+
+    if (( (in_left_bp->strand  + in_right_bp->strand) == 0 ) && // strand plus strand == 0; -1 and 1 ; 1 and -1
+    (in_left_bp->end >= q_left_bp->start) &&                     // left side
+    (in_left_bp->start < q_left_bp->end + slop) &&
+    (in_right_bp->end >= q_right_bp->start) && // right side
+    (in_right_bp->start < q_right_bp->end + slop))
+    return 1;
+
+
+    if (((in_left_bp->strand  + in_right_bp->strand) == 0) && // strand
+        (in_left_bp->end >= q_left_bp->start) &&                     // left side
+        (in_left_bp->start < q_left_bp->end + slop) &&
+        (in_right_bp->end >= q_right_bp->start) && // right side
+        (in_right_bp->start < q_right_bp->end + slop))
+        return 1;
+   
 
     return 0;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -18,6 +18,12 @@
 
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 
+#ifndef ZXCDEBUG
+    #define ZXCDEBUG
+
+#endif
+
+
 uint32_t safe_sub(uint32_t a, uint32_t b)
 {
     if (a < b)
@@ -319,6 +325,9 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
             return 0;
     }
 
+
+
+
     // Ignore "chr" prefix
     char *q_chrm_test = q_right_bp->chrm;
     char *in_chrm_test = in_right_bp->chrm;
@@ -353,7 +362,33 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
     // Make sure the right sides intersect 
     if ( (in_right_bp->end >= q_right_bp->start) &&       // end after start
          (in_right_bp->start < q_right_bp->end + slop) )  // start before end
+        {
+
+        // #ifdef ZXCDEBUG
+        //     fprintf(stderr,
+        //             "debug: "
+        //             "query_left:%s %u %u\tresult_left:%s %u %u\tquery_right:%s %u %u\tresult_right:%s %u %u\n", 
+        //             q_left_bp->chrm, 
+        //             q_left_bp->start,
+        //             q_left_bp->end,
+
+                    
+        //             in_left_bp->chrm, 
+        //             in_left_bp->start,
+        //             in_left_bp->end,
+
+        //             q_right_bp->chrm, 
+        //             q_right_bp->start,
+        //             q_right_bp->end,
+
+        //             in_right_bp->chrm, 
+        //             in_right_bp->start,
+        //             in_right_bp->end
+        //             );
+        // #endif
+
         return 1;
+        }
     else
         return 0;
 }
@@ -463,7 +498,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                struct uint_pair **sample_alt_depths)
 {
 
-#if DEBUG
+
     fprintf(stderr,
             "stix_run_giggle_query: "
             "left:%s %u %u\tright:%s %u %u\n", 
@@ -473,7 +508,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
             q_right_bp->chrm, 
             q_right_bp->start,
             q_right_bp->end);
-#endif
+
 
     if (*gi == NULL) {
         *gi = giggle_load(giggle_index_dir,
@@ -559,10 +594,13 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                                    q_start,
                                                    q_end,
                                                    NULL);
-
+    //DEBUG
+    // printf("gqr->num_files:%d\nnum_samples:%d\n",gqr->num_files,num_samples);
     uint32_t i, N = gqr->num_files;
-    if ((sample_ids != NULL) & (num_samples > 0))
+    if ((sample_ids != NULL) & (num_samples > 0)){
         N = num_samples;
+        // printf("N was modified...");
+    }
 
     if (*sample_alt_depths == NULL)
         *sample_alt_depths =
@@ -589,6 +627,22 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                              &in_left_bp,
                                              &in_right_bp,
                                              &evidence_type);
+
+            // #ifdef ZXCDEBUG
+            //     fprintf(stderr,
+            //             "query result: "
+            //             "left:%s %u %u\tright:%s %u %u\n", 
+            //             in_left_bp->chrm, 
+            //             in_left_bp->start,
+            //             in_left_bp->end,
+            //             in_right_bp->chrm, 
+            //             in_right_bp->start,
+            //             in_right_bp->end);
+            // #endif
+
+
+
+
             uint32_t hit = stix_check_sv(q_left_bp,
                                          q_right_bp,
                                          in_left_bp,
@@ -601,6 +655,31 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                     (*sample_alt_depths)[i].first += 1; //pairend-read
                 else
                     (*sample_alt_depths)[i].second += 1; //split-reads
+                
+
+                        #ifdef ZXCDEBUG
+                            fprintf(stderr,
+                                    "#debug: "
+                                    "query_left:%s %u %u\tresult_left:%s %u %u\tquery_right:%s %u %u\tresult_right:%s %u %u\t%s\n", 
+                                    q_left_bp->chrm, 
+                                    q_left_bp->start,
+                                    q_left_bp->end,
+
+                                    
+                                    in_left_bp->chrm, 
+                                    in_left_bp->start,
+                                    in_left_bp->end,
+
+                                    q_right_bp->chrm, 
+                                    q_right_bp->start,
+                                    q_right_bp->end,
+
+                                    in_right_bp->chrm, 
+                                    in_right_bp->start,
+                                    in_right_bp->end,
+                                    result
+                                    );
+                        #endif
             }
         }
         giggle_iter_destroy(&gqi);

--- a/src/search.c
+++ b/src/search.c
@@ -58,6 +58,12 @@ uint32_t stix_parse_result(char *result,
                            struct stix_breakpoint **right,
                            uint32_t *evidence_type)
 {
+
+    if (V_is_set ==1){
+        fprintf(stderr,"##stix_parse_result--results: %s\n",result);
+        fflush(stderr);
+    }
+
     if (*left == NULL)
     {
         *left = (struct stix_breakpoint *)
@@ -423,8 +429,8 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
             ov = -1.0;
             if (V_is_set)
             {
-                printf("#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
-                fflush(stdout);
+                fprintf(stderr,"#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
+                fflush(stderr);
             }
             // return 0;
         }
@@ -452,8 +458,8 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
             ov = -1.0;
             if (V_is_set)
             {
-                printf("#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
-                fflush(stdout);
+                fprintf(stderr,"#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
+                fflush(stderr);
             }
         }
         else
@@ -475,8 +481,8 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
 
     if (V_is_set)
     {
-        printf("#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
-        fflush(stdout);
+        fprintf(stderr,"#overlap: ov:%f,min_len:%f, in_left_bp->start: %d, in_right_bp->start: %d, in_left_bp->end: %d, in_right_bp->end: %d\n", ov, min_len, in_left_bp->start, in_right_bp->start, in_left_bp->end, in_right_bp->end);
+        fflush(stderr);
     }
     if (ov > 0.0)
     {
@@ -576,14 +582,14 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
 
             if (V_is_set)
             {
-                printf("#ins hit:exact match\n");
-                fflush(stdout);
-                printf("#ins debug exact match: \n# in_right_bp->start: %d, q_right_bp->end: %d,\n",
+                fprintf(stderr,"#ins hit:exact match\n");
+                fflush(stderr);
+                fprintf(stderr,"#ins debug exact match: \n# in_right_bp->start: %d, q_right_bp->end: %d,\n",
 
                        in_right_bp->start,
 
                        q_left_bp->end);
-                fflush(stdout);
+                fflush(stderr);
             }
 
             // further compare length. beacuse multiple insertions exists in same insert point.
@@ -648,11 +654,11 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
             {
                 if (V_is_set)
                 {
-                    printf("#ins debug: found distance of quey: %d  and results:%d are more than slop %d \n",
+                    fprintf(stderr,"#ins debug: found distance of quey: %d  and results:%d are more than slop %d \n",
                            q_left_bp->end,
                            in_left_bp->end,
                            slop);
-                    fflush(stdout);
+                    fflush(stderr);
                 }
 
                 return 0;
@@ -671,7 +677,7 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                 }
                 if (V_is_set == 1)
                 {
-                    printf("#ins debug: \n#  in_right_bp->end: %d, in_right_bp->start: %d, results_len: %d\n#  q_right_bp->end: %d, q_right_bp->start: %d, query_len: %d  \n#  pct: %f\n",
+                    fprintf(stderr,"#ins debug: \n#  in_right_bp->end: %d, in_right_bp->start: %d, results_len: %d\n#  q_right_bp->end: %d, q_right_bp->start: %d, query_len: %d  \n#  pct: %f\n",
                            in_right_bp->end,
                            in_right_bp->start,
                            (in_right_bp->end - in_right_bp->start),
@@ -679,7 +685,7 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                            q_right_bp->start,
                            (q_right_bp->end - q_right_bp->start),
                            pct);
-                    fflush(stdout);
+                    fflush(stderr);
                 }
 
                 // if relative error less than a
@@ -689,8 +695,8 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                     if (V_is_set == 1)
                     {
 
-                        printf("#ins hit:OV <0.2\n");
-                        fflush(stdout);
+                        fprintf(stderr,"#ins hit:OV <0.2\n");
+                        fflush(stderr);
                     }
 
                     return 1;
@@ -712,8 +718,8 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
 
                     if (V_is_set == 1)
                     {
-                        printf("#ins hit: no-length hit\n");
-                        fflush(stdout);
+                        fprintf(stderr,"#ins hit: no-length hit\n");
+                        fflush(stderr);
                     }
 
                     return 1;
@@ -1023,6 +1029,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                             in_right_bp->start,
                             in_right_bp->end,
                             results2);
+                    fflush(stderr);
                 }
             }
             else
@@ -1048,6 +1055,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                             in_right_bp->start,
                             in_right_bp->end,
                             results2);
+                    fflush(stderr);
                 }
             }
         }
@@ -1223,10 +1231,16 @@ uint32_t stix_get_summary(struct uint_pair *sample_alt_depths,
         else
             idx = i;
 
-        sum = sample_alt_depths[idx].first + sample_alt_depths[idx].second;
+        /*from xinchang
+        sample_alt_depths counts the number of evidence == 0 and number of evidence ==1 which is in the seventh column of excord output
+        evidence == 0 ==> paird reads evidence
+        evidence == 1 ==> split reads evidence
+        if you do a sum of sample_alt_depths, you are counting the number of split reads evidence
+        */
+        sum = sample_alt_depths[idx].first + sample_alt_depths[idx].second; 
         if (sum == 0)
             *zero_count = *zero_count + 1;
-        else if (sum == 1)
+        else if (sum == 1) /* What happens if there are more than 1 split reads evidence? [Have fixed it at fix_STIX_ONE branch] */
             *one_count = *one_count + 1;
         else
         {
@@ -1286,7 +1300,7 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
 {
     char *sv_type_str = NULL;
     int sv_type_len = 0;
-    uint32_t ret;
+    uint32_t ret,ret_svlen;
 
     int size = sizeof(int32_t);
 
@@ -1318,6 +1332,8 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
         *sv_type = DUP;
     else if (strcmp(sv_type_str, "INV") == 0)
         *sv_type = INV;
+    else if (strcmp(sv_type_str, "INS") == 0)
+        *sv_type = INS;
     else
     {
         fprintf(stderr, "Warning: Skipping variant: Unknown SVTYPE: %s\n", sv_type_str);
@@ -1335,18 +1351,24 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &end,
                              &end_size);
 
-    if (ret == -1)
+    /* from Xinchang
+        Move SVLEN here, beacuse INS always need this tag
+    */
+    int sv_len_size = sizeof(int);
+    int *sv_len = (int *)malloc(sv_len_size);
+    ret_svlen = bcf_get_info_int32(hdr,
+                            line,
+                            "SVLEN",
+                            &sv_len,
+                            &sv_len_size);
+
+    if (ret == -1) // if END is missing,try to calculate the end from SVLEN tag
     {
-        int sv_len_size = sizeof(int);
-        int *sv_len = (int *)malloc(sv_len_size);
 
-        ret = bcf_get_info_int32(hdr,
-                                 line,
-                                 "SVLEN",
-                                 &sv_len,
-                                 &sv_len_size);
 
-        if (ret == -1)
+
+
+        if (ret_svlen == -1)
         {
             fprintf(stderr, "Warning: Skipping variant. No END and NO SVLEN\n");
             free(end);
@@ -1356,8 +1378,9 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
 
         *end = line->pos + *sv_len;
 
-        free(sv_len);
+        
     }
+
 
     if (left->chrm != NULL)
         free(left->chrm);
@@ -1372,17 +1395,51 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &cipos,
                              &ci_size);
 
-    if (ret != -1)
+    if (ret != -1 )
     {
-        left->start += cipos[0];
-        left->end += cipos[1];
+        /*
+        from xinchang:
+        For insertion, we don't need a confident padding 
+        */
+        if (strcmp(sv_type_str, "INS") != 0){
+            left->start += cipos[0];
+            left->end += cipos[1];
+        }
     }
 
     if (right->chrm != NULL)
         free(right->chrm);
-    right->chrm = strdup(chrm);
-    right->start = *end;
-    right->end = *end;
+
+    /*
+    from xinchang,
+    For insertions, The start of right region is equal to the end of left region.
+    Length information is encoded in the end.
+    */
+    if (strcmp(sv_type_str, "INS") != 0){
+        right->chrm = strdup(chrm);
+        right->start = *end;
+        right->end = *end;
+    }else{
+
+        /*from xinchang
+        If an insertion record is missing the SVLEN tag in infos, we should ignore it.
+        */
+        if(ret_svlen == -1){
+           
+            fprintf(stderr, "Warning: Skipping INS due to missing SVLEN.\n");
+            free(end);
+            free(ciend);
+            free(cipos);
+            free(sv_len);
+            return 1;
+ 
+        }else{
+            right->chrm = strdup(chrm);
+            right->start = line->pos;
+            right->end = line->pos + *sv_len; 
+        }
+
+    }
 
     ret = bcf_get_info_int32(hdr,
                              line,
@@ -1391,14 +1448,16 @@ uint32_t stix_get_vcf_breakpoints(htsFile *fp,
                              &ci_size);
     if (ret != -1)
     {
-        right->start += ciend[0];
-        right->end += ciend[1];
+        if (strcmp(sv_type_str, "INS") != 0){
+            right->start += ciend[0];
+            right->end += ciend[1];
+        }
     }
 
     free(end);
     free(ciend);
     free(cipos);
-
+    free(sv_len);
     return 0;
 }
 //}}}

--- a/src/search.c
+++ b/src/search.c
@@ -740,8 +740,13 @@ uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
                     ((q_right_bp->start + ins_padding) > in_right_bp->start))   // start before end
                 {
 
-                    printf("#ins hit: no-length hit\n");
-                    fflush(stdout);
+
+                    if (V_is_set == 1)
+                    {
+                        printf("#ins hit: no-length hit\n");
+                        fflush(stdout);
+                    }
+
                     return 1;
                 }
                 else

--- a/src/search.h
+++ b/src/search.h
@@ -35,6 +35,7 @@ uint32_t stix_run_giggle_query(struct giggle_index **gi,
                                struct stix_breakpoint *q_left_bp,
                                struct stix_breakpoint *q_right_bp,
                                uint32_t slop,
+                               uint32_t ins_padding,
                                uint32_t *sample_ids,
                                uint32_t num_samples,
                                struct uint_pair **sample_alt_depths);
@@ -45,6 +46,7 @@ uint32_t stix_check_sv(struct stix_breakpoint *q_left_bp,
                         struct stix_breakpoint *in_right_bp,
                         uint32_t evidence_type,
                         uint32_t slop,
+                        uint32_t ins_padding,
                         enum stix_sv_type sv_type);
 
 uint32_t stix_check_inv(struct stix_breakpoint *q_left_bp,
@@ -60,6 +62,15 @@ uint32_t stix_check_del(struct stix_breakpoint *q_left_bp,
                         struct stix_breakpoint *in_right_bp,
                         uint32_t evidence_type,
                         uint32_t slop);
+
+uint32_t stix_check_ins(struct stix_breakpoint *q_left_bp,
+                        struct stix_breakpoint *q_right_bp,
+                        struct stix_breakpoint *in_left_bp,
+                        struct stix_breakpoint *in_right_bp,
+                        uint32_t evidence_type,
+                        uint32_t slop,
+                        uint32_t ins_padding
+                        );
 
 uint32_t stix_check_bnd(struct stix_breakpoint *q_left_bp,
                         struct stix_breakpoint *q_right_bp,

--- a/src/stix.c
+++ b/src/stix.c
@@ -44,6 +44,7 @@ int help(int exit_code)
             "         options:\n"
             "             -i  index directory\n"
             "             -s  slop\n"
+            "             -P  padding base piars for query insertion(default 5)\n"
             "             -p  PED file\n"
             "             -c  Alt file column (default 1)\n"
             "             -d  PED database file\n"
@@ -383,7 +384,8 @@ int main(int argc, char **argv)
         F_is_set = 0,
         j_is_set = 0,
         t_is_set = 0,
-        v_is_set = 0;
+        v_is_set = 0,
+        P_is_set = 0;
 
     char *index_dir_name = NULL;
     char *ped_file_name= NULL;
@@ -396,11 +398,12 @@ int main(int argc, char **argv)
     char *sv_type = NULL;
     char *sample_column = NULL;
     uint32_t slop = 0;
+    uint32_t ins_padding = 5;
     uint32_t col_id = 1;
     uint32_t summary_only = 0;
     uint32_t depths_only = 0;
 
-    while((c = getopt (argc, argv, "i:s:p:c:d:r:l:f:a:F:jt:v:SD")) != -1) {
+    while((c = getopt (argc, argv, "i:P:s:p:c:d:r:l:f:a:F:jt:v:SD")) != -1) {
         switch (c) {
             case 'i':
                 i_is_set = 1;
@@ -413,6 +416,10 @@ int main(int argc, char **argv)
             case 'p':
                 p_is_set = 1;
                 ped_file_name = optarg;
+                break;
+            case 'P':
+                P_is_set = 1;
+                ins_padding = atoi(optarg);
                 break;
             case 'c':
                 c_is_set = 1;
@@ -465,6 +472,7 @@ int main(int argc, char **argv)
                 if ( (optopt == 'i') ||
                      (optopt == 's') ||
                      (optopt == 'p') ||
+                     (optopt == 'P') ||
                      (optopt == 'd') ||
                      (optopt == 'r') ||
                      (optopt == 'l') ||
@@ -543,6 +551,8 @@ int main(int argc, char **argv)
                 query_type = INV;
             else if (strcmp(sv_type,"BND") == 0)
                 query_type = BND;
+            else if (strcmp(sv_type,"INS") == 0)
+                query_type = INS;
         
             //DEBUG
             // 这里的num_sample_alt_depths是3，所以导致print_results出错
@@ -553,6 +563,7 @@ int main(int argc, char **argv)
                                           left,
                                           right,
                                           slop,
+                                          ins_padding,
                                           sample_ids,
                                           num_samples,
                                           &sample_alt_depths);
@@ -628,6 +639,7 @@ int main(int argc, char **argv)
                                                   left,
                                                   right,
                                                   slop,
+                                                  ins_padding,
                                                   sample_ids,
                                                   num_samples,
                                                   &sample_alt_depths);

--- a/src/stix.c
+++ b/src/stix.c
@@ -44,7 +44,7 @@ int help(int exit_code)
             "         options:\n"
             "             -i  index directory\n"
             "             -s  slop\n"
-            "             -P  padding base piars for query insertion(default 5)\n"
+            "             -P  padding base piars for query insertion(default 50)\n"
             "             -p  PED file\n"
             "             -c  Alt file column (default 1)\n"
             "             -d  PED database file\n"
@@ -398,7 +398,7 @@ int main(int argc, char **argv)
     char *sv_type = NULL;
     char *sample_column = NULL;
     uint32_t slop = 0;
-    uint32_t ins_padding = 5;
+    uint32_t ins_padding = 50;
     uint32_t col_id = 1;
     uint32_t summary_only = 0;
     uint32_t depths_only = 0;

--- a/src/stix.c
+++ b/src/stix.c
@@ -247,13 +247,15 @@ void print_results(struct giggle_index *gi,
             printf("],\n\"samples\": [\n");
 
         char **col_vals = NULL, **col_names = NULL;
+        // printf("num_samples:%d\n",num_samples);
         for ( i = 0; i < num_samples; ++i ) {
             uint32_t idx;
             if (sample_ids != NULL)
                 idx = sample_ids[i];
             else
                 idx = i;
-
+           
+            // printf("ped_get_cols_info_by_id:%d \n",idx);
             num_col_vals = ped_get_cols_info_by_id(ped_db_file_name,
                                                    &db,
                                                    NULL,
@@ -541,7 +543,9 @@ int main(int argc, char **argv)
                 query_type = INV;
             else if (strcmp(sv_type,"BND") == 0)
                 query_type = BND;
-
+        
+            //DEBUG
+            // 这里的num_sample_alt_depths是3，所以导致print_results出错
             uint32_t num_sample_alt_depths = 
                     stix_run_giggle_query(&gi,
                                           index_dir_name,
@@ -552,7 +556,8 @@ int main(int argc, char **argv)
                                           sample_ids,
                                           num_samples,
                                           &sample_alt_depths);
-
+            //DEBUG
+            // printf("num_sample_alt_depths:%d\n",num_sample_alt_depths);
             print_results(gi,
                           ped_db_file_name,
                           left,
@@ -652,7 +657,7 @@ int main(int argc, char **argv)
                         for (i = 0; i < num_sample_alt_depths; ++i) {
                             if (sample_alt_depths[i].first + 
                                 sample_alt_depths[i].second > 0) {
-
+                                
                                 char **col_vals = NULL, **col_names = NULL;
                                 num_col_vals = ped_get_cols_info_by_id(
                                         ped_db_file_name,

--- a/src/stix.c
+++ b/src/stix.c
@@ -554,8 +554,7 @@ int main(int argc, char **argv)
             else if (strcmp(sv_type,"INS") == 0)
                 query_type = INS;
         
-            //DEBUG
-            // 这里的num_sample_alt_depths是3，所以导致print_results出错
+            
             uint32_t num_sample_alt_depths = 
                     stix_run_giggle_query(&gi,
                                           index_dir_name,

--- a/src/stix.c
+++ b/src/stix.c
@@ -13,7 +13,7 @@
 #include "ped.h"
 #include "search.h"
 
-char *stix_sv_type_strings[5] = { "DEL", "DUP", "INS", "INV", "BND" };
+char *stix_sv_type_strings[5] = {"DEL", "DUP", "INS", "INV", "BND"};
 
 uint32_t parse_aggregate_csv(char *aggregate,
                              char ***agg_cols);
@@ -54,10 +54,13 @@ int help(int exit_code)
             "             -a  List of columns to aggregate over\n"
             "             -F  Filter samples by PED field query\n"
             "             -j  JSON output\n"
-            "             -t  SV type \n"
+            "             -t  SV type (DEL,INS,INV,DUP,BND) \n"
+            "             -L  Length of Insertion(use it when -t INS) \n"
+            "             -R  Relative Erorr Threshold to compare the length of query INS and targeted INS (0.0-1.0) (default:0.15) \n"
             "             -v  Add sample depth to VCF file\n"
             "             -S  Give only summary\n"
-            "             -D  Give sample depth array\n");
+            "             -D  Give sample depth array\n"
+            "             -V  Verbose mode(print debug information, will increase output file size greatly)\n");
     return exit_code;
 }
 //}}}
@@ -78,7 +81,7 @@ void print_results(struct giggle_index *gi,
                    uint32_t depths_only)
 {
     uint32_t i;
-    
+
     uint32_t num_col_vals;
     int32_t zero_count, one_count;
     uint32_t Q1, Q2, Q3, min, max;
@@ -96,10 +99,11 @@ void print_results(struct giggle_index *gi,
                                     &max,
                                     counts);
 
-    if (json_out == 1) 
+    if (json_out == 1)
         printf("{ \"results\": {\n");
 
-    if (json_out == 1) {
+    if (json_out == 1)
+    {
         printf("\"summary\": [\n");
 
         printf("{"
@@ -112,26 +116,33 @@ void print_results(struct giggle_index *gi,
                one_count,
                Q1, Q2, Q3,
                counts[0], counts[1], counts[2], counts[3]);
-    } else {
+    }
+    else
+    {
         printf("Total\t0:1\t%d:%d\t%u:%u:%u\t%d:%d:%d:%d",
-               zero_count, one_count, 
+               zero_count, one_count,
                Q1, Q2, Q3,
                counts[0], counts[1], counts[2], counts[3]);
     }
 
-    if (depths_only == 1) {
+    if (depths_only == 1)
+    {
         uint32_t *sample_depths = NULL;
         ret = stix_get_sample_depths(sample_alt_depths,
                                      NULL,
                                      num_samples,
                                      &sample_depths);
-        if (json_out == 0) {
-            for ( i = 0; i < num_samples; ++i) 
+        if (json_out == 0)
+        {
+            for (i = 0; i < num_samples; ++i)
                 printf("\t%d", sample_depths[i]);
-        } else {
+        }
+        else
+        {
             printf(",\"depths\":[");
-            for ( i = 0; i < num_samples; ++i) {
-                if (i != 0 )
+            for (i = 0; i < num_samples; ++i)
+            {
+                if (i != 0)
                     printf(",");
                 printf("%d", sample_depths[i]);
             }
@@ -140,14 +151,15 @@ void print_results(struct giggle_index *gi,
 
         free(sample_depths);
     }
-    
-    if (json_out == 1) 
+
+    if (json_out == 1)
         printf("}");
     printf("\n");
 
     sqlite3 *db = NULL;
-         
-    if (num_agg_cols > 0) {
+
+    if (num_agg_cols > 0)
+    {
         char ***uniq_vals;
         uint32_t num_uniq_vals;
         uint32_t **uniq_groups_ids;
@@ -161,11 +173,13 @@ void print_results(struct giggle_index *gi,
                                                 &uniq_groups_ids,
                                                 &uniq_groups_sizes);
 
-        for (i = 0; i < num_uniq_vals; ++i) {
+        for (i = 0; i < num_uniq_vals; ++i)
+        {
             uint32_t j;
             char *group_name_tmp, *group_name;
             ret = asprintf(&group_name, "%s", uniq_vals[i][0]);
-            for (j = 1; j < num_agg_cols; ++j) {
+            for (j = 1; j < num_agg_cols; ++j)
+            {
                 ret = asprintf(&group_name_tmp,
                                "%s,%s",
                                group_name,
@@ -186,7 +200,8 @@ void print_results(struct giggle_index *gi,
                                    &max,
                                    counts);
 
-            if (json_out) {
+            if (json_out)
+            {
                 printf(",{"
                        "\"name\":\"%s\", "
                        "\"zero_count\":\"%d\", "
@@ -198,28 +213,35 @@ void print_results(struct giggle_index *gi,
                        one_count,
                        Q1, Q2, Q3,
                        counts[0], counts[1], counts[2], counts[3]);
-            } else  {
+            }
+            else
+            {
                 printf("%s\t0:1\t%d:%d\t%u:%u:%u\t%d:%d:%d:%d",
                        group_name,
-                       zero_count, one_count, 
+                       zero_count, one_count,
                        Q1, Q2, Q3,
                        counts[0], counts[1], counts[2], counts[3]);
             }
 
-            if (depths_only == 1) {
+            if (depths_only == 1)
+            {
                 uint32_t *sample_depths = NULL;
                 ret = stix_get_sample_depths(sample_alt_depths,
                                              uniq_groups_ids[i],
                                              uniq_groups_sizes[i],
                                              &sample_depths);
                 int k;
-                if (json_out == 0) {
-                    for ( k = 0; k < uniq_groups_sizes[i]; ++k)
+                if (json_out == 0)
+                {
+                    for (k = 0; k < uniq_groups_sizes[i]; ++k)
                         printf("\t%d", sample_depths[k]);
-                } else {
+                }
+                else
+                {
                     printf(",\"depths\":[");
-                    for ( k = 0; k < uniq_groups_sizes[i]; ++k) {
-                        if (k != 0 )
+                    for (k = 0; k < uniq_groups_sizes[i]; ++k)
+                    {
+                        if (k != 0)
                             printf(",");
                         printf("%d", sample_depths[k]);
                     }
@@ -236,26 +258,28 @@ void print_results(struct giggle_index *gi,
         }
     }
 
-    if (summary_only == 1) {
-        if (json_out == 1) 
+    if (summary_only == 1)
+    {
+        if (json_out == 1)
             printf("]}}");
         return;
     }
 
-   
-    if (depths_only == 0) {
+    if (depths_only == 0)
+    {
         if (json_out)
             printf("],\n\"samples\": [\n");
 
         char **col_vals = NULL, **col_names = NULL;
         // printf("num_samples:%d\n",num_samples);
-        for ( i = 0; i < num_samples; ++i ) {
+        for (i = 0; i < num_samples; ++i)
+        {
             uint32_t idx;
             if (sample_ids != NULL)
                 idx = sample_ids[i];
             else
                 idx = i;
-           
+
             // printf("ped_get_cols_info_by_id:%d \n",idx);
             num_col_vals = ped_get_cols_info_by_id(ped_db_file_name,
                                                    &db,
@@ -266,38 +290,42 @@ void print_results(struct giggle_index *gi,
                                                    &col_names);
 
             uint32_t j;
-            if (json_out == 1) {
+            if (json_out == 1)
+            {
                 if (i > 0)
                     printf(",");
 
                 printf("{");
-                for ( j = 0; j < num_col_vals; ++j ) {
+                for (j = 0; j < num_col_vals; ++j)
+                {
                     if (j > 0)
                         printf(",");
                     printf("\"%s\":\"%s\"", col_names[j], col_vals[j]);
                 }
                 printf(",\"Pairend\":\"%u\",\"Split\":\"%u\"}\n",
-                        sample_alt_depths[i].first,
-                        sample_alt_depths[i].second);
-
-            } else {
-                if (i == 0) {
-                    for ( j = 0; j < num_col_vals; ++j)
+                       sample_alt_depths[i].first,
+                       sample_alt_depths[i].second);
+            }
+            else
+            {
+                if (i == 0)
+                {
+                    for (j = 0; j < num_col_vals; ++j)
                         printf("%s\t", col_names[j]);
                     printf("Pairend\tSplit\n");
                 }
 
-                for ( j = 0; j < num_col_vals; ++j )
+                for (j = 0; j < num_col_vals; ++j)
                     printf("%s\t", col_vals[j]);
 
                 printf("%u\t%u\n",
-                        sample_alt_depths[i].first,
-                        sample_alt_depths[i].second);
+                       sample_alt_depths[i].first,
+                       sample_alt_depths[i].second);
             }
         }
     }
 
-    if (json_out == 1) 
+    if (json_out == 1)
         printf("]}}");
 
     sqlite3_close(db);
@@ -310,18 +338,20 @@ uint32_t parse_aggregate_csv(char *aggregate,
 {
     uint32_t i;
     uint32_t num_agg_cols = 1;
-    for (i = 0; i < strlen(aggregate); ++i) {
+    for (i = 0; i < strlen(aggregate); ++i)
+    {
         if (aggregate[i] == ',')
             num_agg_cols += 1;
     }
 
-    *agg_cols = (char **)malloc(num_agg_cols*sizeof(char*));
+    *agg_cols = (char **)malloc(num_agg_cols * sizeof(char *));
 
     char *p = strtok(aggregate, ",");
     uint32_t col_i = 0;
-    while (p != NULL) {
+    while (p != NULL)
+    {
         (*agg_cols)[col_i] = p;
-        col_i+=1;
+        col_i += 1;
         p = strtok(NULL, ",");
     }
 
@@ -334,32 +364,33 @@ void update_vcf_header(bcf_hdr_t *hdr,
                        uint32_t v_is_set,
                        char *sample_column)
 {
-    char *STIX_QUANTS_LINE = 
+    char *STIX_QUANTS_LINE =
         "##INFO=<ID=STIX_QUANTS,Number=3,Type=Integer,"
         "Description=\"STIX quantile values.\">";
     if (bcf_hdr_append(hdr, STIX_QUANTS_LINE) != 0)
         errx(EX_DATAERR, "Error updating header\n");
 
-    char *STIX_QUANT_DEPTHS_LINE = 
+    char *STIX_QUANT_DEPTHS_LINE =
         "##INFO=<ID=STIX_QUANT_DEPTHS,Number=4,Type=Integer,"
         "Description=\"STIX quantile depths.\">";
     if (bcf_hdr_append(hdr, STIX_QUANT_DEPTHS_LINE) != 0)
         errx(EX_DATAERR, "Error updating header\n");
 
-    char *STIX_ZERO_LINE = 
+    char *STIX_ZERO_LINE =
         "##INFO=<ID=STIX_ZERO,Number=1,Type=Integer,"
         "Description=\"STIX samples with zero evidence.\">";
     if (bcf_hdr_append(hdr, STIX_ZERO_LINE) != 0)
         errx(EX_DATAERR, "Error updating header\n");
 
-    char *STIX_ONE_LINE = 
+    char *STIX_ONE_LINE =
         "##INFO=<ID=STIX_ONE,Number=1,Type=Integer,"
         "Description=\"STIX samples with one piece of evidence.\">";
     if (bcf_hdr_append(hdr, STIX_ONE_LINE) != 0)
         errx(EX_DATAERR, "Error updating header\n");
 
-    if (v_is_set == 1) {
-        char *STIX_SAMPLE_DEPTH_LINE = 
+    if (v_is_set == 1)
+    {
+        char *STIX_SAMPLE_DEPTH_LINE =
             "##INFO=<ID=STIX_SAMPLE_DEPTH,Number=.,Type=String,"
             "Description=\"STIX sample-level depth information.\">";
         if (bcf_hdr_append(hdr, STIX_SAMPLE_DEPTH_LINE) != 0)
@@ -367,6 +398,12 @@ void update_vcf_header(bcf_hdr_t *hdr,
     }
 }
 //}}}
+
+int V_is_set = 0; // init global Verbose mode
+int L_is_set = 0; // init global Length of Insertions
+int R_is_set = 0;
+uint32_t length_of_insertion = 0;
+float ovpct_threshold = 0.15;
 
 //{{{int main(int argc, char **argv)
 int main(int argc, char **argv)
@@ -388,125 +425,142 @@ int main(int argc, char **argv)
         P_is_set = 0;
 
     char *index_dir_name = NULL;
-    char *ped_file_name= NULL;
-    char *ped_db_file_name= NULL;
-    char *vcf_file_name= NULL;
+    char *ped_file_name = NULL;
+    char *ped_db_file_name = NULL;
+    char *vcf_file_name = NULL;
     char *r_region = NULL;
     char *l_region = NULL;
     char *aggregate = NULL;
     char *filter = NULL;
     char *sv_type = NULL;
     char *sample_column = NULL;
+
     uint32_t slop = 0;
     uint32_t ins_padding = 50;
     uint32_t col_id = 1;
     uint32_t summary_only = 0;
     uint32_t depths_only = 0;
 
-    while((c = getopt (argc, argv, "i:P:s:p:c:d:r:l:f:a:F:jt:v:SD")) != -1) {
-        switch (c) {
-            case 'i':
-                i_is_set = 1;
-                index_dir_name = optarg;
-                break;
-            case 's':
-                s_is_set = 1;
-                slop = atoi(optarg); 
-                break;
-            case 'p':
-                p_is_set = 1;
-                ped_file_name = optarg;
-                break;
-            case 'P':
-                P_is_set = 1;
-                ins_padding = atoi(optarg);
-                break;
-            case 'c':
-                c_is_set = 1;
-                col_id = atoi(optarg); 
-                break;
-            case 'd':
-                d_is_set = 1;
-                ped_db_file_name = optarg;
-                break;
-            case 'r':
-                r_is_set = 1;
-                r_region = optarg; 
-                break;
-            case 'l':
-                l_is_set = 1;
-                l_region = optarg; 
-                break;
-            case 'f':
-                f_is_set = 1;
-                vcf_file_name = optarg; 
-                break;
-            case 'a':
-                a_is_set = 1;
-                aggregate = optarg;
-                break;
-            case 'F':
-                F_is_set = 1;
-                filter = optarg;
-                break;
-            case 'j':
-                j_is_set = 1;
-                break;
-            case 't':
-                t_is_set = 1;
-                sv_type = optarg;
-                break;
-            case 'v':
-                v_is_set = 1;
-                sample_column = optarg;
-                break;
-            case 'S':
-                summary_only = 1;
-                break;
-            case 'D':
-                depths_only = 1;
-                break;
-            case 'h':
-                return help(EX_OK);
-            case '?':
-                if ( (optopt == 'i') ||
-                     (optopt == 's') ||
-                     (optopt == 'p') ||
-                     (optopt == 'P') ||
-                     (optopt == 'd') ||
-                     (optopt == 'r') ||
-                     (optopt == 'l') ||
-                     (optopt == 'f') ||
-                     (optopt == 'a') ||
-                     (optopt == 'F') ||
-                     (optopt == 't') ||
-                     (optopt == 'v') )
-                    fprintf (stderr,
-                             "Option -%c requires an argument.\n",
-                             optopt);
-                else if (isprint (optopt))
-                    fprintf (stderr,
-                             "Unknown option `-%c'.\n",
-                             optopt);
-                else
-                    fprintf(stderr,
-                            "Unknown option character `\\x%x'.\n",
-                            optopt);
+    while ((c = getopt(argc, argv, "i:P:s:p:c:d:r:l:f:a:F:jt:v:SDVL:R:")) != -1)
+    {
+        switch (c)
+        {
+        case 'i':
+            i_is_set = 1;
+            index_dir_name = optarg;
+            break;
+        case 's':
+            s_is_set = 1;
+            slop = atoi(optarg);
+            break;
+        case 'p':
+            p_is_set = 1;
+            ped_file_name = optarg;
+            break;
+        case 'P':
+            P_is_set = 1;
+            ins_padding = atoi(optarg);
+            break;
+        case 'c':
+            c_is_set = 1;
+            col_id = atoi(optarg);
+            break;
+        case 'd':
+            d_is_set = 1;
+            ped_db_file_name = optarg;
+            break;
+        case 'r':
+            r_is_set = 1;
+            r_region = optarg;
+            break;
+        case 'l':
+            l_is_set = 1;
+            l_region = optarg;
+            break;
+        case 'f':
+            f_is_set = 1;
+            vcf_file_name = optarg;
+            break;
+        case 'a':
+            a_is_set = 1;
+            aggregate = optarg;
+            break;
+        case 'F':
+            F_is_set = 1;
+            filter = optarg;
+            break;
+        case 'j':
+            j_is_set = 1;
+            break;
+        case 't':
+            t_is_set = 1;
+            sv_type = optarg;
+            break;
+        case 'L':
+            L_is_set = 1;
+            length_of_insertion = atoi(optarg);
+            break;
+        case 'R':
+            R_is_set = 1;
+            ovpct_threshold = atof(optarg);
+            break;
+        case 'v':
+            v_is_set = 1;
+            sample_column = optarg;
+            break;
+        case 'S':
+            summary_only = 1;
+            break;
+        case 'D':
+            depths_only = 1;
+            break;
+        case 'V':
+            V_is_set = 1;
+            break;
+        case 'h':
+            return help(EX_OK);
+        case '?':
+            if ((optopt == 'i') ||
+                (optopt == 's') ||
+                (optopt == 'p') ||
+                (optopt == 'P') ||
+                (optopt == 'd') ||
+                (optopt == 'r') ||
+                (optopt == 'l') ||
+                (optopt == 'f') ||
+                (optopt == 'a') ||
+                (optopt == 'F') ||
+                (optopt == 't') ||
+                (optopt == 'L') ||
+                (optopt == 'R') ||
+                (optopt == 'v'))
+                fprintf(stderr,
+                        "Option -%c requires an argument.\n",
+                        optopt);
+            else if (isprint(optopt))
+                fprintf(stderr,
+                        "Unknown option `-%c'.\n",
+                        optopt);
+            else
+                fprintf(stderr,
+                        "Unknown option character `\\x%x'.\n",
+                        optopt);
 
-                return help(EX_USAGE);
-            default:
-                return help(EX_OK);
+            return help(EX_USAGE);
+        default:
+            return help(EX_OK);
         }
     }
 
     char **agg_cols = NULL;
     uint32_t num_agg_cols = 0;
-    if (a_is_set == 1) 
+    if (a_is_set == 1)
         num_agg_cols = parse_aggregate_csv(aggregate, &agg_cols);
 
-    if ((i_is_set == 1) && 
-        (p_is_set == 1) && 
-        (d_is_set == 1)) {
+    if ((i_is_set == 1) &&
+        (p_is_set == 1) &&
+        (d_is_set == 1))
+    {
 
         uint32_t num_rows = ped_create_db(ped_file_name,
                                           ped_db_file_name,
@@ -520,13 +574,14 @@ int main(int argc, char **argv)
         return EX_OK;
     }
 
-    if ((i_is_set == 1) &&  // giggle index
-        (d_is_set == 1) &&  // ped db
-        (s_is_set == 1) ) { // slop
+    if ((i_is_set == 1) && // giggle index
+        (d_is_set == 1) && // ped db
+        (s_is_set == 1))
+    { // slop
 
         uint32_t *sample_ids = NULL;
         uint32_t num_samples = 0;
-        if (F_is_set == 1) 
+        if (F_is_set == 1)
             num_samples = ped_get_matching_sample_ids(ped_db_file_name,
                                                       filter,
                                                       &sample_ids);
@@ -536,38 +591,38 @@ int main(int argc, char **argv)
         struct uint_pair *sample_alt_depths = NULL;
         struct stix_breakpoint *left = NULL, *right = NULL;
 
-        if ((l_is_set == 1) &&  // left interval
-            (r_is_set == 1) &&  // right interval
-            (t_is_set == 1) ) { // sv type
+        if ((l_is_set == 1) && // left interval
+            (r_is_set == 1) && // right interval
+            (t_is_set == 1))
+        { // sv type
 
             left = stix_region_to_breakpoint(l_region);
             right = stix_region_to_breakpoint(r_region);
 
             enum stix_sv_type query_type = DEL;
 
-            if (strcmp(sv_type,"DUP") == 0)
+            if (strcmp(sv_type, "DUP") == 0)
                 query_type = DUP;
-            else if (strcmp(sv_type,"INV") == 0)
+            else if (strcmp(sv_type, "INV") == 0)
                 query_type = INV;
-            else if (strcmp(sv_type,"BND") == 0)
+            else if (strcmp(sv_type, "BND") == 0)
                 query_type = BND;
-            else if (strcmp(sv_type,"INS") == 0)
+            else if (strcmp(sv_type, "INS") == 0)
                 query_type = INS;
-        
-            
-            uint32_t num_sample_alt_depths = 
-                    stix_run_giggle_query(&gi,
-                                          index_dir_name,
-                                          query_type,
-                                          left,
-                                          right,
-                                          slop,
-                                          ins_padding,
-                                          sample_ids,
-                                          num_samples,
-                                          &sample_alt_depths);
-            //DEBUG
-            // printf("num_sample_alt_depths:%d\n",num_sample_alt_depths);
+
+            uint32_t num_sample_alt_depths =
+                stix_run_giggle_query(&gi,
+                                      index_dir_name,
+                                      query_type,
+                                      left,
+                                      right,
+                                      slop,
+                                      ins_padding,
+                                      sample_ids,
+                                      num_samples,
+                                      &sample_alt_depths);
+            // DEBUG
+            //  printf("num_sample_alt_depths:%d\n",num_sample_alt_depths);
             print_results(gi,
                           ped_db_file_name,
                           left,
@@ -586,10 +641,12 @@ int main(int argc, char **argv)
             free(left);
             free(right->chrm);
             free(right);
-        } else if (f_is_set == 1) {
+        }
+        else if (f_is_set == 1)
+        {
 
             htsFile *fp = hts_open(vcf_file_name, "r");
-            if ( !fp )
+            if (!fp)
                 err(EX_DATAERR, "Could not read file: %s", vcf_file_name);
 
             bcf_hdr_t *hdr = bcf_hdr_read(fp);
@@ -598,17 +655,17 @@ int main(int argc, char **argv)
 
             update_vcf_header(hdr, v_is_set, sample_column);
 
-            htsFile *out_f = hts_open("-","w");
+            htsFile *out_f = hts_open("-", "w");
             bcf_hdr_write(out_f, hdr);
 
             bcf1_t *line = bcf_init1();
 
             left = (struct stix_breakpoint *)
-                    malloc(sizeof(struct stix_breakpoint));
+                malloc(sizeof(struct stix_breakpoint));
             left->chrm = NULL;
 
             right = (struct stix_breakpoint *)
-                    malloc(sizeof(struct stix_breakpoint));
+                malloc(sizeof(struct stix_breakpoint));
             right->chrm = NULL;
 
             enum stix_sv_type type;
@@ -617,31 +674,34 @@ int main(int argc, char **argv)
             char **cols = NULL;
             uint32_t num_cols = 0;
 
-            if (v_is_set == 1) {
-                cols = (char **) malloc(sizeof(char *));
+            if (v_is_set == 1)
+            {
+                cols = (char **)malloc(sizeof(char *));
                 cols[0] = sample_column;
                 num_cols = 1;
             }
 
-            while (bcf_read(fp, hdr, line) == 0) {
+            while (bcf_read(fp, hdr, line) == 0)
+            {
                 if (stix_get_vcf_breakpoints(fp,
                                              hdr,
                                              line,
                                              left,
                                              right,
-                                             &type) == 0) {
+                                             &type) == 0)
+                {
 
-                    uint32_t num_sample_alt_depths = 
-                            stix_run_giggle_query(&gi,
-                                                  index_dir_name,
-                                                  type,
-                                                  left,
-                                                  right,
-                                                  slop,
-                                                  ins_padding,
-                                                  sample_ids,
-                                                  num_samples,
-                                                  &sample_alt_depths);
+                    uint32_t num_sample_alt_depths =
+                        stix_run_giggle_query(&gi,
+                                              index_dir_name,
+                                              type,
+                                              left,
+                                              right,
+                                              slop,
+                                              ins_padding,
+                                              sample_ids,
+                                              num_samples,
+                                              &sample_alt_depths);
 
                     uint32_t i;
                     uint32_t num_col_vals;
@@ -660,37 +720,44 @@ int main(int argc, char **argv)
                                                     &min,
                                                     &max,
                                                     counts);
-                
-                    if (v_is_set == 1) {
+
+                    if (v_is_set == 1)
+                    {
                         char *stix_sample_depth_string = NULL,
                              *tmp_string = NULL;
 
-                        for (i = 0; i < num_sample_alt_depths; ++i) {
-                            if (sample_alt_depths[i].first + 
-                                sample_alt_depths[i].second > 0) {
-                                
+                        for (i = 0; i < num_sample_alt_depths; ++i)
+                        {
+                            if (sample_alt_depths[i].first +
+                                    sample_alt_depths[i].second >
+                                0)
+                            {
+
                                 char **col_vals = NULL, **col_names = NULL;
                                 num_col_vals = ped_get_cols_info_by_id(
-                                        ped_db_file_name,
-                                        &db,
-                                        cols,
-                                        num_cols,
-                                        i,
-                                        &col_vals,
-                                        &col_names);
-                                if (stix_sample_depth_string != NULL) {
+                                    ped_db_file_name,
+                                    &db,
+                                    cols,
+                                    num_cols,
+                                    i,
+                                    &col_vals,
+                                    &col_names);
+                                if (stix_sample_depth_string != NULL)
+                                {
                                     ret = asprintf(&tmp_string,
                                                    "%s,%s|%u",
                                                    stix_sample_depth_string,
                                                    col_vals[0],
-                                                   sample_alt_depths[i].first + 
-                                                   sample_alt_depths[i].second);
-                                } else {
+                                                   sample_alt_depths[i].first +
+                                                       sample_alt_depths[i].second);
+                                }
+                                else
+                                {
                                     ret = asprintf(&tmp_string,
                                                    "%s|%u",
                                                    col_vals[0],
-                                                   sample_alt_depths[i].first + 
-                                                   sample_alt_depths[i].second);
+                                                   sample_alt_depths[i].first +
+                                                       sample_alt_depths[i].second);
                                 }
                                 free(stix_sample_depth_string);
                                 stix_sample_depth_string = tmp_string;
@@ -702,12 +769,13 @@ int main(int argc, char **argv)
                             }
                         }
 
-                        if (stix_sample_depth_string != NULL) {
+                        if (stix_sample_depth_string != NULL)
+                        {
                             ret = bcf_update_info_string(
-                                    hdr,
-                                    line,
-                                    "STIX_SAMPLE_DEPTH",
-                                    stix_sample_depth_string);
+                                hdr,
+                                line,
+                                "STIX_SAMPLE_DEPTH",
+                                stix_sample_depth_string);
                             if (ret != 0)
                                 errx(EX_DATAERR,
                                      "Error adding STIX_SAMPLE_DEPTH to "
@@ -733,7 +801,7 @@ int main(int argc, char **argv)
                         errx(EX_DATAERR,
                              "Error adding STIX_ONE to info field.\n");
 
-                    uint32_t quants[3] = {Q1,Q2,Q3};
+                    uint32_t quants[3] = {Q1, Q2, Q3};
                     ret = bcf_update_info_int32(hdr,
                                                 line,
                                                 "STIX_QUANTS",
@@ -754,16 +822,15 @@ int main(int argc, char **argv)
 
                     bcf_write(out_f, hdr, line);
 
-
                     /*
                     fprintf(stdout,
                             "0:1\t%d:%d\t%u:%u:%u\t%d:%d:%d:%d\n",
-                            zero_count, one_count, 
+                            zero_count, one_count,
                             Q1, Q2, Q3,
                             counts[0], counts[1], counts[2], counts[3]);
                     */
 
-                    //free(sample_alt_depths);
+                    // free(sample_alt_depths);
                 }
             }
 
@@ -780,7 +847,8 @@ int main(int argc, char **argv)
 
         if (sample_alt_depths != NULL)
             free(sample_alt_depths);
-        if (gi != NULL) {
+        if (gi != NULL)
+        {
             giggle_index_destroy(&gi);
             cache.destroy();
         }


### PR DESCRIPTION
1. Add some code to handle the insertion. Basically, the insertions will be encoded as a specially left and right pair with a 0 base pair interval. STIX will query this region normally and then only consider results that have this pattern and are located within the slop. Next, STIX will compare the query region with results one by one. Length information will be used if both the query and results have it. A relative error (default threshold: 0.15) is used to compare the length differences between the query and each result. If there is no length information available, STIX will report insertions within 50bp of the query by default.
2. Add additional code for handling the strand in LR. For short reads, INV will generate read pairs with the same strand; however, long reads will generate two different strands (+-, -+).
3. Add additional command line options
    >-P padding base pairs for query insertion (default 50)
-L Length of Insertion (use it when -t INS)
-R Relative Error Threshold to compare the length of query INS and targeted INS (0.0-1.0) (default: 0.15)
-V Verbose mode (print debug information, will increase output file size greatly)